### PR TITLE
fix(ci): install required build dependencies

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           rust-version: stable
 
+      - name: Install dependencies
+        run: sudo apt install libfreetype-dev libfontconfig-dev
+
       - name: Compile
         shell: bash
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,6 +25,9 @@ jobs:
 
     - uses: dtolnay/rust-toolchain@stable
 
+    - name: Install dependencies
+      run: sudo apt install libfreetype-dev libfontconfig-dev
+
     - name: Download LAZ file
       run: curl -L "https://cdn.routechoic.es/test.laz" -o test_file.laz
 
@@ -119,6 +122,9 @@ jobs:
         fetch-depth: 2
 
     - uses: dtolnay/rust-toolchain@stable
+
+    - name: Install dependencies
+      run: sudo apt install libfreetype-dev libfontconfig-dev
 
     - name: Download LAZ file
       run: curl -L "https://cdn.routechoic.es/test.laz" -o test_file.laz

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install dependencies
+        run: sudo apt install libfreetype-dev libfontconfig-dev
+
       - name: Check
         run: cargo check --all-features --all-targets
 
@@ -32,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt install libfreetype-dev libfontconfig-dev
 
       - name: Unit Tests
         run: cargo test


### PR DESCRIPTION
Fix CI by installing the `freetype` and `fontconfig` libraries required for `skia-safe`.