### PR TITLE
use bigger buffer size when reading and writing large files

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -39,7 +39,7 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
     let white = Rgba([255, 255, 255, 255]);
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz.bin");
-    let file = BufReader::new(fs.open(&xyz_file_in)?);
+    let file = BufReader::with_capacity(crate::ONE_MEGABYTE, fs.open(&xyz_file_in)?);
     let mut reader = XyzInternalReader::new(file).unwrap();
     while let Some(r) = reader.next().unwrap() {
         let (x, y, h) = (r.x, r.y, r.z);

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -96,7 +96,10 @@ pub fn makecliffs(
     let mut rng = rand::thread_rng();
     let randdist = distributions::Bernoulli::new(cliff_thin).unwrap();
 
-    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
+        crate::ONE_MEGABYTE,
+        fs.open(&xyz_file_in)?,
+    ))?;
     while let Some(r) = reader.next()? {
         if cliff_thin == 1.0 || rng.sample(randdist) {
             let (x, y, h) = (r.x, r.y, r.z);

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -35,7 +35,10 @@ pub fn xyz2heightmap(
     let mut hmax: f64 = f64::MIN;
 
     let xyz_file_in = tmpfolder.join(xyzfilein);
-    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
+        crate::ONE_MEGABYTE,
+        fs.open(&xyz_file_in)?,
+    ))?;
     while let Some(r) = reader.next()? {
         let x: f64 = r.x;
         let y: f64 = r.y;
@@ -76,7 +79,10 @@ pub fn xyz2heightmap(
     // a two-dimensional vector of (sum, count) pairs for computing averages
     let mut list_alt = Vec2D::new(w + 2, h + 2, (0f64, 0usize));
 
-    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
+        crate::ONE_MEGABYTE,
+        fs.open(&xyz_file_in)?,
+    ))?;
     while let Some(r) = reader.next()? {
         if r.classification == 2 || r.classification == water_class {
             let x: f64 = r.x;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,5 @@ pub mod vegetation;
 
 #[cfg(feature = "shapefile")]
 pub mod shapefile;
+
+const ONE_MEGABYTE: usize = 1024 * 1024;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,6 @@ pub mod vegetation;
 #[cfg(feature = "shapefile")]
 pub mod shapefile;
 
+/// The size of a megabyte in bytes. Used for Read/Write buffer sizes for large files, instead of
+/// the default 8KB.
 const ONE_MEGABYTE: usize = 1024 * 1024;

--- a/src/process.rs
+++ b/src/process.rs
@@ -112,7 +112,8 @@ pub fn process_tile(
         info!("Converting points from .xyz to internal binary format");
 
         debug!("Writing records to {:?}", &target_file);
-        let mut writer = XyzInternalWriter::new(BufWriter::new(
+        let mut writer = XyzInternalWriter::new(BufWriter::with_capacity(
+            crate::ONE_MEGABYTE,
             fs.create(&target_file).expect("Could not create writer"),
         ));
         read_lines_no_alloc(fs, input_file, |line| {

--- a/src/process.rs
+++ b/src/process.rs
@@ -157,13 +157,15 @@ pub fn process_tile(
         let mut rng = rand::thread_rng();
         let randdist = distributions::Bernoulli::new(thinfactor).unwrap();
 
-        let mut reader = Reader::new(BufReader::new(
+        let mut reader = Reader::new(BufReader::with_capacity(
+            crate::ONE_MEGABYTE,
             fs.open(input_file).expect("Could not open file"),
         ))
         .expect("Could not create reader");
 
         debug!("Writing records to {:?}", &target_file);
-        let mut writer = XyzInternalWriter::new(BufWriter::new(
+        let mut writer = XyzInternalWriter::new(BufWriter::with_capacity(
+            crate::ONE_MEGABYTE,
             fs.create(&target_file).expect("Could not create writer"),
         ));
 
@@ -415,7 +417,8 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
 
         let tmp_filename = PathBuf::from(format!("temp{}.xyz.bin", thread));
         debug!("Writing records to {:?}", &tmp_filename);
-        let mut writer = XyzInternalWriter::new(BufWriter::new(
+        let mut writer = XyzInternalWriter::new(BufWriter::with_capacity(
+            crate::ONE_MEGABYTE,
             fs.create(&tmp_filename).expect("Could not create writer"),
         ));
 
@@ -428,9 +431,11 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 && header.max_y > miny2
                 && header.min_y < maxy2
             {
-                let mut reader =
-                    Reader::new(BufReader::new(fs.open(laz_p).expect("Could not open file")))
-                        .expect("Could not create reader");
+                let mut reader = Reader::new(BufReader::with_capacity(
+                    crate::ONE_MEGABYTE,
+                    fs.open(laz_p).expect("Could not open file"),
+                ))
+                .expect("Could not create reader");
                 for ptu in reader.points() {
                     let pt = ptu.unwrap();
                     if pt.x > minx2

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -70,7 +70,10 @@ pub fn makevege(
     let mut noyhit: HashMap<(u64, u64), u64> = HashMap::default();
 
     let mut i = 0;
-    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
+        crate::ONE_MEGABYTE,
+        fs.open(&xyz_file_in)?,
+    ))?;
     while let Some(r) = reader.next()? {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
@@ -125,7 +128,10 @@ pub fn makevege(
     let step: f32 = 6.0;
 
     let mut i = 0;
-    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
+        crate::ONE_MEGABYTE,
+        fs.open(&xyz_file_in)?,
+    ))?;
     while let Some(r) = reader.next()? {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
@@ -464,7 +470,10 @@ pub fn makevege(
     let buildings = config.buildings;
     let water = config.water;
     if buildings > 0 || water > 0 {
-        let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
+        let mut reader = XyzInternalReader::new(BufReader::with_capacity(
+            crate::ONE_MEGABYTE,
+            fs.open(&xyz_file_in)?,
+        ))?;
         while let Some(r) = reader.next()? {
             let (x, y) = (r.x, r.y);
             let c: u8 = r.classification;


### PR DESCRIPTION
Increases the buffer size when reading and writing large files (eg. the conversion into `.xyz.bin` files and reading of the same) from the default 8KiB to 1MB. This means fewer syscalls to the operating system and thus a small speedup in processing.

Here are some comparison tables of the number and time spent in syscalls for the test `laz` file on my computer (captured usince `strace -c`):

**Before**
```
[2025-02-03T11:57:58Z ThreadId(1) DEBUG pullauta::util] [timing: process_tile] Stopping timing. Total: 52.104s elapsed.
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 68.72    1.412254           1    709497           read
 11.68    0.240137        2638        91           openat
  7.59    0.156014           1    146707           write
  6.52    0.133980        5825        23           munmap
  3.90    0.080175         881        91           close
  1.20    0.024570           8      2762           brk
  0.36    0.007484        3742         2           copy_file_range
  0.01    0.000229           3        74           ioctl
  0.00    0.000099           1        78           mmap
  0.00    0.000053           1        27         7 statx
  0.00    0.000032           3         9           lseek
  0.00    0.000016           3         5           rt_sigaction
  0.00    0.000013           6         2         2 mkdir
  0.00    0.000012           3         4           getrandom
  0.00    0.000011           3         3           sigaltstack
  0.00    0.000007           0        15           mprotect
  0.00    0.000006           6         1           sched_getaffinity
  0.00    0.000005           5         1           fchmod
  0.00    0.000000           0        14           fstat
  0.00    0.000000           0         1           poll
  0.00    0.000000           0         2           pread64
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           futex
  0.00    0.000000           0         1           set_tid_address
  0.00    0.000000           0         1           set_robust_list
  0.00    0.000000           0         2           prlimit64
  0.00    0.000000           0         1           rseq
------ ----------- ----------- --------- --------- ------------------
100.00    2.055097           2    859418        10 total
```


**After**
```
[2025-02-03T11:59:28Z ThreadId(1) DEBUG pullauta::util] [timing: process_tile] Stopping timing. Total: 39.818s elapsed.
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 28.45    0.404708          10     36950           write
 20.83    0.296395          10     28456           read
 19.20    0.273159        3001        91           close
 17.88    0.254447        2796        91           openat
 10.67    0.151796        6324        24           munmap
  2.36    0.033513          12      2765           brk
  0.54    0.007649        3824         2           copy_file_range
  0.04    0.000593           7        79           mmap
  0.01    0.000184           2        74           ioctl
  0.01    0.000126           8        15           mprotect
  0.00    0.000049           3        14           fstat
  0.00    0.000044           1        27         7 statx
  0.00    0.000021          10         2           pread64
  0.00    0.000017           1         9           lseek
  0.00    0.000012           3         4           getrandom
  0.00    0.000009           4         2         2 mkdir
  0.00    0.000008           4         2           prlimit64
  0.00    0.000005           5         1           fchmod
  0.00    0.000005           5         1           futex
  0.00    0.000004           4         1           arch_prctl
  0.00    0.000004           4         1           set_tid_address
  0.00    0.000004           4         1           set_robust_list
  0.00    0.000004           4         1           rseq
  0.00    0.000001           0         3           sigaltstack
  0.00    0.000000           0         1           poll
  0.00    0.000000           0         5           rt_sigaction
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           sched_getaffinity
------ ----------- ----------- --------- --------- ------------------
100.00    1.422757          20     68625        10 total
```

As you can see, on my device the total processing time decreases from 52 to 39 seconds, and the number of (relatively expensive) syscalls have decreased :rocket: Performance improvements are of course quite hardware-dependent, but this should be an improvement overall IMO.