### PR TITLE
update skia-safe to make windows arm build 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -629,7 +629,7 @@ dependencies = [
  "approx",
  "getrandom 0.2.16",
  "image",
- "itertools 0.12.1",
+ "itertools",
  "nalgebra",
  "num",
  "rand 0.8.5",
@@ -675,15 +675,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1252,7 +1243,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools 0.12.1",
+ "itertools",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -1496,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.84.0"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b612a544c0cc0da82271eac1c40b6b055fe3c5aa20bb7b3922f830c777d9aff0"
+checksum = "a2bf215f640b53293844d441e93448b437ca4937595f60e3317fbb03d7ac6783"
 dependencies = [
  "bindgen",
  "cc",
@@ -1513,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.84.0"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2629d473f8bdbe35fc227d80d8efe9a7db538a409be8beb19e5cd3153d10b0ef"
+checksum = "e372258f52414e04de007326fa497581617c9fa872a3225dca5e42212723c426"
 dependencies = [
  "bitflags 2.9.0",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand = "0.9"
 rust-ini = "0.21"
 rustc-hash = "2.0"
 shapefile = { version = "0.6.0", optional = true }
-skia-safe = { version = "0.84", optional = true }
+skia-safe = { version = "0.86", optional = true }
 zip = { version = "2.3", default-features = false, features = [
 	"bzip2",
 	"deflate",


### PR DESCRIPTION
Fixes #183 by updating `skia-safe` bindings to latest release which includes pre-built binaries for windows arm64 :rocket:

See https://github.com/antbern/rusty-pullauta/actions/runs/15556430745/job/43798164912 for a successful CI run.