### PR TITLE
chore(lint): fix clippy warnings in format strings

### DIFF
--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -122,15 +122,14 @@ pub fn makecliffs(
         .expect("Unable to create file");
     let mut f2 = BufWriter::new(f2);
 
-    write!(&mut f2,"  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{}\r\n 20\r\n{}\r\n  9\r\n$EXTMAX\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n", xmin, ymin, xmax, ymax).expect("Cannot write dxf file");
+    write!(&mut f2,"  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{xmin}\r\n 20\r\n{ymin}\r\n  9\r\n$EXTMAX\r\n 10\r\n{xmax}\r\n 20\r\n{ymax}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n").expect("Cannot write dxf file");
 
     let f3 = fs
         .create(tmpfolder.join("c3g.dxf"))
         .expect("Unable to create file");
     let mut f3 = BufWriter::new(f3);
 
-    write!(&mut f3, "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{}\r\n 20\r\n{}\r\n  9\r\n$EXTMAX\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n",
-            xmin, ymin, xmax, ymax
+    write!(&mut f3, "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{xmin}\r\n 20\r\n{ymin}\r\n  9\r\n$EXTMAX\r\n 10\r\n{xmax}\r\n 20\r\n{ymax}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n"
     ).expect("Cannot write dxf file");
 
     // temporary vector to reuse memory allocations

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,8 +170,7 @@ impl Config {
         let mut thinfactor: f64 = parse_typed(gs, "thinfactor", 1.0);
         if !(0.0..=1.0).contains(&thinfactor) {
             return Err(format!(
-                "Value {} of `thinfactor` is outside the allowed range of 0.0 to 1.0",
-                thinfactor
+                "Value {thinfactor} of `thinfactor` is outside the allowed range of 0.0 to 1.0"
             )
             .into());
         }
@@ -222,8 +221,7 @@ impl Config {
         let cliff_thin: f64 = parse_typed(gs, "cliffthin", 1.0);
         if !(0.0..=1.0).contains(&cliff_thin) {
             return Err(format!(
-                "Value {} of `cliffthin` is outside the allowed range of 0.0 to 1.0",
-                cliff_thin
+                "Value {cliff_thin} of `cliffthin` is outside the allowed range of 0.0 to 1.0"
             )
             .into());
         }
@@ -236,7 +234,7 @@ impl Config {
         let mut zones = vec![];
         let mut i: u32 = 1;
         loop {
-            let zone = gs.get(format!("zone{}", i)).unwrap_or("");
+            let zone = gs.get(format!("zone{i}")).unwrap_or("");
             if zone.is_empty() {
                 break;
             }
@@ -255,7 +253,7 @@ impl Config {
             let mut thresholds = vec![];
             let mut i: u32 = 1;
             loop {
-                let last_threshold = gs.get(format!("thresold{}", i)).unwrap_or("");
+                let last_threshold = gs.get(format!("thresold{i}")).unwrap_or("");
                 if last_threshold.is_empty() {
                     break;
                 }

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -213,8 +213,7 @@ pub fn xyz2heightmap(
         for y in 0..avg_alt.height() {
             if avg_alt[(x, y)].is_nan() {
                 panic!(
-                    "heightmap should not have any nans, found NaN at ({}, {})",
-                    x, y
+                    "heightmap should not have any nans, found NaN at ({x}, {y})"
                 );
             }
         }
@@ -510,8 +509,7 @@ pub fn heightmap2contours(
 
     write!(
         &mut f,
-        "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{}\r\n 20\r\n{}\r\n  9\r\n$EXTMAX\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n",
-        xmin, ymin, xmax, ymax,
+        "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{xmin}\r\n 20\r\n{ymin}\r\n  9\r\n$EXTMAX\r\n 10\r\n{xmax}\r\n 20\r\n{ymax}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n",
     ).expect("Cannot write dxf file");
 
     read_lines_no_alloc(fs, polyline_out, |line| {
@@ -531,8 +529,7 @@ pub fn heightmap2contours(
                 let y: f64 = xy_raw.next().unwrap().parse::<f64>().unwrap() * size + ymin;
                 write!(
                     &mut f,
-                    "VERTEX\r\n  8\r\ncont\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\n",
-                    x, y
+                    "VERTEX\r\n  8\r\ncont\r\n 10\r\n{x}\r\n 20\r\n{y}\r\n  0\r\n"
                 )
                 .expect("Cannot write dxf file");
             }

--- a/src/crop.rs
+++ b/src/crop.rs
@@ -29,7 +29,7 @@ pub fn polylinedxfcrop(
         if j > 0 {
             if let Some((head, rec2)) = rec.split_once("VERTEX") {
                 let r: Vec<&str> = rec2.split("VERTEX").collect();
-                poly.push_str(&format!("POLYLINE{}", head));
+                poly.push_str(&format!("POLYLINE{head}"));
                 for apu in r.iter() {
                     let (apu2, _notused) = apu.split_once("SEQEND").unwrap_or((apu, ""));
                     let val: Vec<&str> = apu2.split('\n').collect();
@@ -48,20 +48,20 @@ pub fn polylinedxfcrop(
                     let valy = val[yline].trim().parse::<f64>().unwrap_or(0.0);
                     if valx >= minx && valx <= maxx && valy >= miny && valy <= maxy {
                         if !pre.is_empty() && pointcount == 0 && (prex < minx || prey < miny) {
-                            poly.push_str(&format!("VERTEX{}", pre));
+                            poly.push_str(&format!("VERTEX{pre}"));
                             pointcount += 1;
                         }
-                        poly.push_str(&format!("VERTEX{}", apu));
+                        poly.push_str(&format!("VERTEX{apu}"));
                         pointcount += 1;
                     } else if pointcount > 1 {
                         if valx < minx || valy < miny {
-                            poly.push_str(&format!("VERTEX{}", apu));
+                            poly.push_str(&format!("VERTEX{apu}"));
                         }
                         if !poly.contains("SEQEND") {
                             poly.push_str("SEQEND\r\n0\r\n");
                         }
                         out.push_str(&poly);
-                        poly = format!("POLYLINE{}", head);
+                        poly = format!("POLYLINE{head}");
                         pointcount = 0;
                     }
                     pre = apu2;
@@ -119,10 +119,10 @@ pub fn pointdxfcrop(
             let val4 = val[4].trim().parse::<f64>().unwrap_or(0.0);
             let val6 = val[6].trim().parse::<f64>().unwrap_or(0.0);
             if val4 >= minx && val4 <= maxx && val6 >= miny && val6 <= maxy {
-                write!(fp, "POINT{}", rec).expect("Could not write file");
+                write!(fp, "POINT{rec}").expect("Could not write file");
             }
         }
     }
-    write!(fp, "ENDSEC{}", ending).expect("Could not write file");
+    write!(fp, "ENDSEC{ending}").expect("Could not write file");
     Ok(())
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -34,10 +34,10 @@ pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io:
         let mut writer = BufWriter::new(fs.create(output)?);
 
         for (x, y, h) in hmap.iter() {
-            writeln!(writer, "{} {} {}", x, y, h)?;
+            writeln!(writer, "{x} {y} {h}")?;
         }
     } else {
-        panic!("Unknown internal file format: {}", input);
+        panic!("Unknown internal file format: {input}");
     }
 
     Ok(())

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -131,8 +131,7 @@ pub fn dotknolls(
 
             write!(
                 &mut f,
-                "POINT\r\n  8\r\n{}\r\n 10\r\n{}\r\n 20\r\n{}\r\n 50\r\n0\r\n  0\r\n",
-                layer, x, y
+                "POINT\r\n  8\r\n{layer}\r\n 10\r\n{x}\r\n 20\r\n{y}\r\n 50\r\n0\r\n  0\r\n"
             )
             .expect("Can not write to file");
         }
@@ -188,8 +187,7 @@ pub fn knolldetector(
         .expect("Unable to create file");
     let mut f = BufWriter::new(f);
     write!(&mut f,
-        "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{}\r\n 20\r\n{}\r\n  9\r\n$EXTMAX\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n",
-        xmin, ymin, xmax, ymax
+        "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{xmin}\r\n 20\r\n{ymin}\r\n  9\r\n$EXTMAX\r\n 10\r\n{xmax}\r\n 20\r\n{ymax}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n"
     ).expect("Cannot write dxf file");
 
     let mut heads1: HashMap<String, usize> = HashMap::default();
@@ -234,14 +232,14 @@ pub fn knolldetector(
                 let y0 = y.first().unwrap();
                 let yl = y.last().unwrap();
 
-                let head = format!("{}x{}", x0, y0);
-                let tail = format!("{}x{}", xl, yl);
+                let head = format!("{x0}x{y0}");
+                let tail = format!("{xl}x{yl}");
 
                 heads.push(head);
                 tails.push(tail);
 
-                let head = format!("{}x{}", x0, y0);
-                let tail = format!("{}x{}", xl, yl);
+                let head = format!("{x0}x{y0}");
+                let tail = format!("{xl}x{yl}");
 
                 el_x.push(x);
                 el_y.push(y);
@@ -1062,7 +1060,7 @@ pub fn xyzknolls(
                 if hit % 2 == 1 {
                     let tmp = xyz2.grid[(ii, jj)] + move1;
                     xyz2.grid[(ii, jj)] = tmp;
-                    let coords = format!("{}_{}", ii, jj);
+                    let coords = format!("{ii}_{jj}");
                     touched.insert(coords, true);
                 }
             }
@@ -1075,7 +1073,7 @@ pub fn xyzknolls(
                 let ii: f64 = xx - range + iii as f64;
                 let jj: f64 = yy - range + jjj as f64;
                 if ii > 0.0 && ii < xmax as f64 && jj > 0.0 && jj < ymax as f64 {
-                    let coords = format!("{}_{}", ii, jj);
+                    let coords = format!("{ii}_{jj}");
                     if !*touched.get(&coords).unwrap_or(&false) {
                         let tmp = xyz2.grid[(ii.floor() as usize, jj.floor() as usize)]
                             + (range - (xx - ii).abs()) / range * (range - (yy - jj).abs()) / range

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,14 +61,13 @@ fn main() {
     {
         const VERSION: &str = env!("CARGO_PKG_VERSION");
         println!(
-            "Karttapullautin v{}\nThere is no warranty. Use it at your own risk!\n",
-            VERSION
+            "Karttapullautin v{VERSION}\nThere is no warranty. Use it at your own risk!\n"
         );
     }
 
     let batch: bool = config.batch;
 
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
+    let tmpfolder = PathBuf::from(format!("temp{thread}"));
     fs::create_dir_all(&tmpfolder).expect("Could not create tmp folder");
 
     let pnorthlinesangle = config.pnorthlinesangle;
@@ -374,7 +373,7 @@ fn main() {
         if config.experimental_use_in_memory_fs {
             let fs = pullauta::io::fs::memory::MemoryFileSystem::new();
 
-            debug!("Copying input file into memory fs: {}", command);
+            debug!("Copying input file into memory fs: {command}");
             // copy the input file into the memory file system
             fs.load_from_disk(Path::new(&command), Path::new("input.laz"))
                 .expect("Could not copy input file into memory fs");
@@ -395,7 +394,7 @@ fn main() {
             // now write the output files to disk
             fn copy(fs: &MemoryFileSystem, name: &str) {
                 if fs.exists(name) {
-                    info!("Copying {} from memory fs to disk", name);
+                    info!("Copying {name} from memory fs to disk");
                     fs.save_to_disk(name, name)
                         .expect("Could not copy from memory fs to disk");
                 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -27,7 +27,7 @@ fn merge_png(
     let mut res = f64::NAN;
     for png in png_files.iter() {
         let filename = png.as_path().file_name().unwrap().to_str().unwrap();
-        let full_filename = format!("{}/{}", batchoutfolder, filename);
+        let full_filename = format!("{batchoutfolder}/{filename}");
         let img = fs
             .read_image_png(&full_filename)
             .expect("Opening image failed");
@@ -67,7 +67,7 @@ fn merge_png(
     );
     for png in png_files.iter() {
         let filename = png.as_path().file_name().unwrap().to_str().unwrap();
-        let png = format!("{}/{}", batchoutfolder, filename);
+        let png = format!("{batchoutfolder}/{filename}");
         let pgw = png.replace(".png", ".pgw");
         let png = Path::new(&png);
         let pgw = Path::new(&pgw);
@@ -98,7 +98,7 @@ fn merge_png(
 
     im.write_to(
         &mut BufWriter::new(
-            fs.create(format!("{}.jpg", outfilename))
+            fs.create(format!("{outfilename}.jpg"))
                 .expect("could not save output jpg"),
         ),
         image::ImageFormat::Jpeg,
@@ -107,7 +107,7 @@ fn merge_png(
 
     im.write_to(
         &mut BufWriter::new(
-            fs.create(format!("{}.png", outfilename))
+            fs.create(format!("{outfilename}.png"))
                 .expect("could not save output png"),
         ),
         image::ImageFormat::Png,
@@ -115,7 +115,7 @@ fn merge_png(
     .expect("could not save output Png");
 
     let tfw_file = fs
-        .create(format!("{}.pgw", outfilename))
+        .create(format!("{outfilename}.pgw"))
         .expect("Unable to create file");
     let mut tfw_out = BufWriter::new(tfw_file);
     write!(
@@ -129,8 +129,8 @@ fn merge_png(
     .expect("Could not write to file");
     tfw_out.flush().expect("Cannot flush");
     fs.copy(
-        Path::new(&format!("{}.pgw", outfilename)),
-        Path::new(&format!("{}.jgw", outfilename)),
+        Path::new(&format!("{outfilename}.pgw")),
+        Path::new(&format!("{outfilename}.jgw")),
     )
     .expect("Could not copy file");
     Ok(())
@@ -223,7 +223,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("contours.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -270,7 +270,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("_c2f.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -308,7 +308,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("_c2g.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -352,7 +352,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
         for dx in dxf_files.iter() {
             let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-            let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+            let dxf_filename = format!("{batchoutfolder}/{dxf}");
             let input = Path::new(&dxf_filename);
             if fs.exists(input) && dxf_filename.ends_with("_basemap.dxf") {
                 let data = fs.read_to_string(input).expect("Can not read input file");
@@ -391,7 +391,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("_c3g.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -429,7 +429,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("_formlines.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -469,7 +469,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("_dotknolls.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -509,7 +509,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
 
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
-        let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
+        let dxf_filename = format!("{batchoutfolder}/{dxf}");
         let input = Path::new(&dxf_filename);
         if fs.exists(input) && dxf_filename.ends_with("_detected.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
@@ -603,7 +603,7 @@ pub fn smoothjoin(
     let mut dxfheadtmp = data[0];
     dxfheadtmp = dxfheadtmp.split("ENDSEC").collect::<Vec<&str>>()[0];
     dxfheadtmp = dxfheadtmp.split("HEADER").collect::<Vec<&str>>()[1];
-    let dxfhead = &format!("HEADER{}ENDSEC", dxfheadtmp);
+    let dxfhead = &format!("HEADER{dxfheadtmp}ENDSEC");
 
     let output = tmpfolder.join("out2.dxf");
     let fp = fs.create(output).expect("Unable to create file");
@@ -667,14 +667,14 @@ pub fn smoothjoin(
             let xl = x.last().unwrap();
             let y0 = y.first().unwrap();
             let yl = y.last().unwrap();
-            let head = format!("{}x{}", x0, y0);
-            let tail = format!("{}x{}", xl, yl);
+            let head = format!("{x0}x{y0}");
+            let tail = format!("{xl}x{yl}");
 
             heads.push(head);
             tails.push(tail);
 
-            let head = format!("{}x{}", x0, y0);
-            let tail = format!("{}x{}", xl, yl);
+            let head = format!("{x0}x{y0}");
+            let tail = format!("{xl}x{yl}");
             el_x.push(x);
             el_y.push(y);
             if *heads1.get(&head).unwrap_or(&0) == 0 {
@@ -933,7 +933,7 @@ pub fn smoothjoin(
                 }
                 x_avg /= (el_x_len - 1) as f64;
                 y_avg /= (el_x_len - 1) as f64;
-                write!(&mut dotknoll_fp, "{} {} {}\r\n", depression, x_avg, y_avg)
+                write!(&mut dotknoll_fp, "{depression} {x_avg} {y_avg}\r\n")
                     .expect("Unable to write to file");
                 skip = true;
             }
@@ -1122,8 +1122,7 @@ pub fn smoothjoin(
                 }
                 write!(
                     fp,
-                    "POLYLINE\r\n 66\r\n1\r\n  8\r\n{}\r\n 38\r\n{}\r\n  0\r\n",
-                    layer, h
+                    "POLYLINE\r\n 66\r\n1\r\n  8\r\n{layer}\r\n 38\r\n{h}\r\n  0\r\n"
                 )
                 .expect("Unable to write file");
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -417,14 +417,14 @@ pub fn render(
     }
 
     let filename = if nodepressions {
-        format!("pullautus{}", thread)
+        format!("pullautus{thread}")
     } else {
-        format!("pullautus_depr{}", thread)
+        format!("pullautus_depr{thread}")
     };
 
     img.write_to(
         &mut BufWriter::new(
-            fs.create(format!("{}.png", filename))
+            fs.create(format!("{filename}.png"))
                 .expect("could not save output png"),
         ),
         image::ImageFormat::Png,
@@ -433,7 +433,7 @@ pub fn render(
 
     let file_in = tmpfolder.join("vegetation.pgw");
     let pgw_file_out = fs
-        .create(format!("{}.pgw", filename))
+        .create(format!("{filename}.pgw"))
         .expect("Unable to create file");
     let mut pgw_file_out = BufWriter::new(pgw_file_out);
 
@@ -445,7 +445,7 @@ pub fn render(
                 write!(&mut pgw_file_out, "{}\r\n", x / 600.0 * 254.0 * scalefactor)
                     .expect("Unable to write to file");
             } else {
-                write!(&mut pgw_file_out, "{}\r\n", ip).expect("Unable to write to file");
+                write!(&mut pgw_file_out, "{ip}\r\n").expect("Unable to write to file");
             }
         }
     }
@@ -874,7 +874,7 @@ pub fn draw_curves(
                 if curvew != 1.5 || formline == 0.0 || help2[i] || smallringtest {
                     if let (Some(fp), true) = (fp.as_mut(), curvew == 1.5) {
                         if !formlinestart {
-                            write!(fp, "POLYLINE\r\n 66\r\n1\r\n  8\r\n{}\r\n  0\r\n", f_label)
+                            write!(fp, "POLYLINE\r\n 66\r\n1\r\n  8\r\n{f_label}\r\n  0\r\n")
                                 .expect("Could not write file");
                             formlinestart = true;
                         }

--- a/src/shapefile/mapping.rs
+++ b/src/shapefile/mapping.rs
@@ -49,8 +49,7 @@ impl FromStr for Mapping {
                     (Operator::Equal, param.splitn(2, "=").collect())
                 } else {
                     return Err(format!(
-                        "Condition does not contain a valid operator: {}",
-                        param
+                        "Condition does not contain a valid operator: {param}"
                     ));
                 };
                 Ok(Condition {

--- a/src/shapefile/mod.rs
+++ b/src/shapefile/mod.rs
@@ -28,7 +28,7 @@ pub fn unzip_and_render(
     }
 
     for zip_name in filenames.iter() {
-        info!("Opening zip file {}", zip_name);
+        info!("Opening zip file {zip_name}");
         let file = fs.open(zip_name).unwrap();
         let mut archive = zip::ZipArchive::new(file).unwrap();
         info!(

--- a/src/shapefile/render.rs
+++ b/src/shapefile/render.rs
@@ -98,13 +98,13 @@ pub fn render(
         }
     }
 
-    info!("Processing shapefiles: {:?}", shp_files);
+    info!("Processing shapefiles: {shp_files:?}");
 
     for shp_file in shp_files.iter() {
         let file = shp_file.as_path().file_name().unwrap().to_str().unwrap();
         let mut file = tmpfolder.join(file);
 
-        info!("Processing shapefile: {:?}", file);
+        info!("Processing shapefile: {file:?}");
         // drawshape comes here
         let mut reader = shapefile::Reader::from_path(&file)?;
         for shape_record in reader.iter_shapes_and_records() {
@@ -125,7 +125,7 @@ pub fn render(
                 let mut luokka = String::new();
                 if let Some(fv) = record.get("LUOKKA") {
                     if let FieldValue::Numeric(Some(f_luokka)) = fv {
-                        luokka = format!("{}", f_luokka);
+                        luokka = format!("{f_luokka}");
                     }
                     if let FieldValue::Character(Some(c_luokka)) = fv {
                         luokka = c_luokka.to_string();
@@ -677,7 +677,7 @@ pub fn render(
         for ext in ["dbf", "sbx", "prj", "shx", "sbn", "cpg", "qmd"].iter() {
             file.set_extension(ext);
             if fs.exists(&file) {
-                println!("Removing file: {:?}", file);
+                println!("Removing file: {file:?}");
                 fs.remove_file(&file).unwrap();
             }
         }

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -692,8 +692,7 @@ pub fn makevege(
     );
     write!(
         &mut writer,
-        "1.0\r\n0.0\r\n0.0\r\n-1.0\r\n{}\r\n{}\r\n",
-        xmin, ymax
+        "1.0\r\n0.0\r\n0.0\r\n-1.0\r\n{xmin}\r\n{ymax}\r\n"
     )
     .expect("Cannot write pgw file");
 


### PR DESCRIPTION
Fixes the recently introduced warnings from `clippy` in format strings :100: 