### PR TITLE
feat: remove use of `temp_polylines.txt` for storing contour paths during computation

### DIFF
--- a/src/contours.rs
+++ b/src/contours.rs
@@ -507,7 +507,7 @@ pub fn heightmap2contours(
             .expect("Cannot write dxf file");
         for (i, (x, y)) in polyline.iter().enumerate() {
             let ii = i + 1;
-            let ldata = polyline.len() - 2;
+            let ldata = polyline.len() - 1;
             if ii > 5 && ii < ldata - 5 && ldata > 12 && ii % 2 == 0 {
                 continue;
             }


### PR DESCRIPTION
The file `temp_polylines.txt` was only used to store the lines during computation, and was then read in to generate the actual `dxf` output. This PR changes this to store the polylines in memory instead, removing the use of a temporary file, which should make it a bit faster (contour generation is already relatively fast compared to vegetation and cliffs) :rocket: 

I hope this file was not used by someone to extract the contour lines. If that is the case, we should provide a way to output this in a more friendly way :+1: 