### PR TITLE
feat: simplify rendering to reduce allocations

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 name: "Regression"
 

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -275,6 +275,8 @@ pub fn makecliffs(
 
     f2.write_all(b"ENDSEC\r\n  0\r\nEOF\r\n")
         .expect("Cannot write dxf file");
+    drop(f2); // close the file
+
     let c2_limit = 2.6 * 2.75;
 
     // if we drop this already here, we can reuse the memory for the second list_alt
@@ -286,8 +288,6 @@ pub fn makecliffs(
         Vec::<(f64, f64, f64)>::new(),
     );
 
-    let mut reader = BufReader::new(fs.open(&heightmap_in)?);
-    let hmap = HeightMap::from_bytes(&mut reader)?;
     for (x, y, h) in hmap.iter() {
         if cliff_thin == 1.0 || rng.sample(randdist) {
             list_alt[(

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn main() {
 
     if command == "render" {
         let angle: f64 = args
-            .get(0)
+            .first()
             .and_then(|s| s.parse::<f64>().ok())
             .expect("expected first argument to be angle");
         let nwidth: usize = args

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,8 +274,14 @@ fn main() {
     }
 
     if command == "render" {
-        let angle: f64 = args[0].parse::<f64>().unwrap();
-        let nwidth: usize = args[1].parse::<usize>().unwrap();
+        let angle: f64 = args
+            .get(0)
+            .and_then(|s| s.parse::<f64>().ok())
+            .expect("expected first argument to be angle");
+        let nwidth: usize = args
+            .get(1)
+            .and_then(|s| s.parse::<usize>().ok())
+            .expect("expected second argument to be nwidth");
         let nodepressions: bool = args.len() > 2 && args[2] == "nodepressions";
         pullauta::render::render(
             &fs,

--- a/src/render.rs
+++ b/src/render.rs
@@ -288,17 +288,6 @@ fn draw_cliffs(
     y0: f64,
 ) -> Result<(), Box<dyn Error>> {
     let scalefactor = config.scalefactor;
-    let black = Rgba([0, 0, 0, 255]);
-
-    let cliffcolor = if config.cliffdebug {
-        HashMap::from_iter([
-            ("cliff2", Rgba([100, 0, 100, 255])),
-            ("cliff3", Rgba([0, 100, 100, 255])),
-            ("cliff4", Rgba([100, 100, 0, 255])),
-        ])
-    } else {
-        HashMap::from_iter([("cliff2", black), ("cliff3", black), ("cliff4", black)])
-    };
 
     let input = tmpfolder.join(file);
     let data = fs.read_to_string(input).expect("Can not read input file");
@@ -340,6 +329,19 @@ fn draw_cliffs(
                 }
             }
         }
+
+        // based on the layer we select the cliffcolor
+        let cliffcolor = if config.cliffdebug {
+            match layer {
+                "cliff2" => Rgba([100, 0, 100, 255]),
+                "cliff3" => Rgba([0, 100, 100, 255]),
+                "cliff4" => Rgba([100, 100, 0, 255]),
+                _ => Rgba([0, 0, 0, 255]), // black
+            }
+        } else {
+            Rgba([0, 0, 0, 255]) // black
+        };
+
         let last_idx = x.len() - 1;
         if x.first() != x.last() || y.first() != y.last() {
             let dist = ((x[0] - x[last_idx]).powi(2) + (y[0] - y[last_idx]).powi(2)).sqrt();
@@ -350,17 +352,12 @@ fn draw_cliffs(
                 y[0] += dy / dist * 1.5;
                 x[last_idx] -= dx / dist * 1.5;
                 y[last_idx] -= dy / dist * 1.5;
-                draw_filled_circle_mut(
-                    img,
-                    (x[0] as i32, y[0] as i32),
-                    3,
-                    *cliffcolor.get(&layer).unwrap_or(&black),
-                );
+                draw_filled_circle_mut(img, (x[0] as i32, y[0] as i32), 3, cliffcolor);
                 draw_filled_circle_mut(
                     img,
                     (x[last_idx] as i32, y[last_idx] as i32),
                     3,
-                    *cliffcolor.get(&layer).unwrap_or(&black),
+                    cliffcolor,
                 );
             }
         }
@@ -377,7 +374,7 @@ fn draw_cliffs(
                             (x[i] + (n as f64) - 3.0).floor() as f32,
                             (y[i] + (m as f64) - 3.0).floor() as f32,
                         ),
-                        *cliffcolor.get(&layer).unwrap_or(&black),
+                        cliffcolor,
                     )
                 }
             }

--- a/src/render.rs
+++ b/src/render.rs
@@ -220,185 +220,9 @@ pub fn render(
         image::imageops::overlay(&mut img, &imgbb_thumb, 0, 0);
     }
 
-    let black = Rgba([0, 0, 0, 255]);
+    draw_cliffs(fs, config, tmpfolder, "c2g.dxf", &mut img, x0, y0).expect("draw cliffs c2g.dxf");
+    draw_cliffs(fs, config, tmpfolder, "c3g.dxf", &mut img, x0, y0).expect("draw cliffs c3g.dxf");
 
-    let mut cliffcolor =
-        HashMap::from_iter([("cliff2", black), ("cliff3", black), ("cliff4", black)]);
-    if config.cliffdebug {
-        cliffcolor = HashMap::from_iter([
-            ("cliff2", Rgba([100, 0, 100, 255])),
-            ("cliff3", Rgba([0, 100, 100, 255])),
-            ("cliff4", Rgba([100, 100, 0, 255])),
-        ]);
-    }
-    let input = tmpfolder.join("c2g.dxf");
-    let data = fs.read_to_string(input).expect("Can not read input file");
-    let data: Vec<&str> = data.split("POLYLINE").collect();
-
-    for (j, rec) in data.iter().enumerate() {
-        let mut x = Vec::<f64>::new();
-        let mut y = Vec::<f64>::new();
-        let mut xline = 0;
-        let mut yline = 0;
-        let mut layer = "";
-        if j > 0 {
-            let r = rec.split("VERTEX").collect::<Vec<&str>>();
-            let apu = r[1];
-            let val = apu.split('\n').collect::<Vec<&str>>();
-            layer = val[2].trim();
-            for (i, v) in val.iter().enumerate() {
-                let vt = v.trim_end();
-                if vt == " 10" {
-                    xline = i + 1;
-                }
-                if vt == " 20" {
-                    yline = i + 1;
-                }
-            }
-            for (i, v) in r.iter().enumerate() {
-                if i > 0 {
-                    let val = v.trim_end().split('\n').collect::<Vec<&str>>();
-                    x.push(
-                        (val[xline].trim().parse::<f64>().unwrap() - x0) * 600.0
-                            / 254.0
-                            / scalefactor,
-                    );
-                    y.push(
-                        (y0 - val[yline].trim().parse::<f64>().unwrap()) * 600.0
-                            / 254.0
-                            / scalefactor,
-                    );
-                }
-            }
-        }
-        let last_idx = x.len() - 1;
-        if x.first() != x.last() || y.first() != y.last() {
-            let dist = ((x[0] - x[last_idx]).powi(2) + (y[0] - y[last_idx]).powi(2)).sqrt();
-            if dist > 0.0 {
-                let dx = x[0] - x[last_idx];
-                let dy = y[0] - y[last_idx];
-                x[0] += dx / dist * 1.5;
-                y[0] += dy / dist * 1.5;
-                x[last_idx] -= dx / dist * 1.5;
-                y[last_idx] -= dy / dist * 1.5;
-                draw_filled_circle_mut(
-                    &mut img,
-                    (x[0] as i32, y[0] as i32),
-                    3,
-                    *cliffcolor.get(&layer).unwrap_or(&black),
-                );
-                draw_filled_circle_mut(
-                    &mut img,
-                    (x[last_idx] as i32, y[last_idx] as i32),
-                    3,
-                    *cliffcolor.get(&layer).unwrap_or(&black),
-                );
-            }
-        }
-        for i in 1..x.len() {
-            for n in 0..6 {
-                for m in 0..6 {
-                    draw_line_segment_mut(
-                        &mut img,
-                        (
-                            (x[i - 1] + (n as f64) - 3.0).floor() as f32,
-                            (y[i - 1] + (m as f64) - 3.0).floor() as f32,
-                        ),
-                        (
-                            (x[i] + (n as f64) - 3.0).floor() as f32,
-                            (y[i] + (m as f64) - 3.0).floor() as f32,
-                        ),
-                        *cliffcolor.get(&layer).unwrap_or(&black),
-                    )
-                }
-            }
-        }
-    }
-
-    let input = &tmpfolder.join("c3g.dxf");
-    let data = fs.read_to_string(input).expect("Can not read input file");
-    let data: Vec<&str> = data.split("POLYLINE").collect();
-
-    for (j, rec) in data.iter().enumerate() {
-        let mut x = Vec::<f64>::new();
-        let mut y = Vec::<f64>::new();
-        let mut xline = 0;
-        let mut yline = 0;
-        let mut layer = "";
-        if j > 0 {
-            let r = rec.split("VERTEX").collect::<Vec<&str>>();
-            let apu = r[1];
-            let val = apu.split('\n').collect::<Vec<&str>>();
-            layer = val[2].trim();
-            for (i, v) in val.iter().enumerate() {
-                let vt = v.trim_end();
-                if vt == " 10" {
-                    xline = i + 1;
-                }
-                if vt == " 20" {
-                    yline = i + 1;
-                }
-            }
-            for (i, v) in r.iter().enumerate() {
-                if i > 0 {
-                    let val = v.trim_end().split('\n').collect::<Vec<&str>>();
-                    x.push(
-                        (val[xline].trim().parse::<f64>().unwrap() - x0) * 600.0
-                            / 254.0
-                            / scalefactor,
-                    );
-                    y.push(
-                        (y0 - val[yline].trim().parse::<f64>().unwrap()) * 600.0
-                            / 254.0
-                            / scalefactor,
-                    );
-                }
-            }
-        }
-        let last_idx = x.len() - 1;
-        if x.first() != x.last() || y.first() != y.last() {
-            let dist = ((x[0] - x[last_idx]).powi(2) + (y[0] - y[last_idx]).powi(2)).sqrt();
-            if dist > 0.0 {
-                let dx = x[0] - x[last_idx];
-                let dy = y[0] - y[last_idx];
-                x[0] += dx / dist * 1.5;
-                y[0] += dy / dist * 1.5;
-                x[last_idx] -= dx / dist * 1.5;
-                y[last_idx] -= dy / dist * 1.5;
-
-                draw_filled_circle_mut(
-                    &mut img,
-                    (x[0] as i32, y[0] as i32),
-                    3,
-                    *cliffcolor.get(&layer).unwrap_or(&black),
-                );
-                draw_filled_circle_mut(
-                    &mut img,
-                    (x[last_idx] as i32, y[last_idx] as i32),
-                    3,
-                    *cliffcolor.get(&layer).unwrap_or(&black),
-                );
-            }
-        }
-        for i in 1..x.len() {
-            for n in 0..6 {
-                for m in 0..6 {
-                    draw_line_segment_mut(
-                        &mut img,
-                        (
-                            (x[i - 1] + (n as f64) - 3.0).floor() as f32,
-                            (y[i - 1] + (m as f64) - 3.0).floor() as f32,
-                        ),
-                        (
-                            (x[i] + (n as f64) - 3.0).floor() as f32,
-                            (y[i] + (m as f64) - 3.0).floor() as f32,
-                        ),
-                        *cliffcolor.get(&layer).unwrap_or(&black),
-                    )
-                }
-            }
-        }
-    }
     // high -------------
     let high_file = tmpfolder.join("high.png");
     if fs.exists(&high_file) {
@@ -451,6 +275,114 @@ pub fn render(
         }
     }
     info!("Done");
+    Ok(())
+}
+
+fn draw_cliffs(
+    fs: &impl FileSystem,
+    config: &Config,
+    tmpfolder: &Path,
+    file: &str,
+    img: &mut ImageBuffer<Rgba<u8>, Vec<u8>>,
+    x0: f64,
+    y0: f64,
+) -> Result<(), Box<dyn Error>> {
+    let scalefactor = config.scalefactor;
+    let black = Rgba([0, 0, 0, 255]);
+
+    let cliffcolor = if config.cliffdebug {
+        HashMap::from_iter([
+            ("cliff2", Rgba([100, 0, 100, 255])),
+            ("cliff3", Rgba([0, 100, 100, 255])),
+            ("cliff4", Rgba([100, 100, 0, 255])),
+        ])
+    } else {
+        HashMap::from_iter([("cliff2", black), ("cliff3", black), ("cliff4", black)])
+    };
+
+    let input = tmpfolder.join(file);
+    let data = fs.read_to_string(input).expect("Can not read input file");
+    let data: Vec<&str> = data.split("POLYLINE").collect();
+
+    for (j, rec) in data.iter().enumerate() {
+        let mut x = Vec::<f64>::new();
+        let mut y = Vec::<f64>::new();
+        let mut xline = 0;
+        let mut yline = 0;
+        let mut layer = "";
+        if j > 0 {
+            let r = rec.split("VERTEX").collect::<Vec<&str>>();
+            let apu = r[1];
+            let val = apu.split('\n').collect::<Vec<&str>>();
+            layer = val[2].trim();
+            for (i, v) in val.iter().enumerate() {
+                let vt = v.trim_end();
+                if vt == " 10" {
+                    xline = i + 1;
+                }
+                if vt == " 20" {
+                    yline = i + 1;
+                }
+            }
+            for (i, v) in r.iter().enumerate() {
+                if i > 0 {
+                    let val = v.trim_end().split('\n').collect::<Vec<&str>>();
+                    x.push(
+                        (val[xline].trim().parse::<f64>().unwrap() - x0) * 600.0
+                            / 254.0
+                            / scalefactor,
+                    );
+                    y.push(
+                        (y0 - val[yline].trim().parse::<f64>().unwrap()) * 600.0
+                            / 254.0
+                            / scalefactor,
+                    );
+                }
+            }
+        }
+        let last_idx = x.len() - 1;
+        if x.first() != x.last() || y.first() != y.last() {
+            let dist = ((x[0] - x[last_idx]).powi(2) + (y[0] - y[last_idx]).powi(2)).sqrt();
+            if dist > 0.0 {
+                let dx = x[0] - x[last_idx];
+                let dy = y[0] - y[last_idx];
+                x[0] += dx / dist * 1.5;
+                y[0] += dy / dist * 1.5;
+                x[last_idx] -= dx / dist * 1.5;
+                y[last_idx] -= dy / dist * 1.5;
+                draw_filled_circle_mut(
+                    img,
+                    (x[0] as i32, y[0] as i32),
+                    3,
+                    *cliffcolor.get(&layer).unwrap_or(&black),
+                );
+                draw_filled_circle_mut(
+                    img,
+                    (x[last_idx] as i32, y[last_idx] as i32),
+                    3,
+                    *cliffcolor.get(&layer).unwrap_or(&black),
+                );
+            }
+        }
+        for i in 1..x.len() {
+            for n in 0..6 {
+                for m in 0..6 {
+                    draw_line_segment_mut(
+                        img,
+                        (
+                            (x[i - 1] + (n as f64) - 3.0).floor() as f32,
+                            (y[i - 1] + (m as f64) - 3.0).floor() as f32,
+                        ),
+                        (
+                            (x[i] + (n as f64) - 3.0).floor() as f32,
+                            (y[i] + (m as f64) - 3.0).floor() as f32,
+                        ),
+                        *cliffcolor.get(&layer).unwrap_or(&black),
+                    )
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -7,7 +7,6 @@ use image::ImageBuffer;
 use image::Rgba;
 use imageproc::drawing::{draw_filled_circle_mut, draw_line_segment_mut};
 use log::info;
-use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
 use std::f64::consts::PI;
 use std::io::BufRead;

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
+use crate::vec2d::Vec2D;
 use image::ImageBuffer;
 use image::Rgba;
 use imageproc::drawing::{draw_filled_circle_mut, draw_line_segment_mut};
@@ -493,12 +494,13 @@ pub fn draw_curves(
         .expect("Could not read line 6")
         .parse::<f64>()
         .unwrap();
-    let mut steepness: HashMap<(usize, usize), f64> = HashMap::default();
 
     let heightmap_in = tmpfolder.join("xyz2.hmap");
     let mut reader = BufReader::new(fs.open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
     let xyz = &hmap.grid;
+
+    let mut steepness = Vec2D::new(xyz.width(), xyz.height(), 0f64);
 
     if formline > 0.0 {
         xstart = hmap.xoffset;
@@ -601,7 +603,7 @@ pub fn draw_curves(
                 if high > val {
                     val = high;
                 }
-                steepness.insert((i, j), val);
+                steepness[(i, j)] = val;
             }
         }
     }
@@ -696,10 +698,10 @@ pub fn draw_curves(
                         as usize;
                     if curvew != 1.5
                         || formline == 0.0
-                        || steepness.get(&(xx, yy)).unwrap_or(&0.0) < &formlinesteepness
-                        || steepness.get(&(xx, yy + 1)).unwrap_or(&0.0) < &formlinesteepness
-                        || steepness.get(&(xx + 1, yy)).unwrap_or(&0.0) < &formlinesteepness
-                        || steepness.get(&(xx + 1, yy + 1)).unwrap_or(&0.0) < &formlinesteepness
+                        || steepness[(xx, yy)] < formlinesteepness
+                        || steepness[(xx, yy + 1)] < formlinesteepness
+                        || steepness[(xx + 1, yy)] < formlinesteepness
+                        || steepness[(xx + 1, yy + 1)] < formlinesteepness
                     {
                         help[i] = true;
                     }


### PR DESCRIPTION
Some work on the `render` functions to improve performance:

- Instead of using a `HashMap` for storing the steepness I decided to go with a `Vec2D` since all values are populated anyways. Improves cache efficiency!
- The code for drawing contour lines / curves was using a lot of temporary allocations while parsing the `.dxf` files. I moved the allocations out of some loops so that they can simply be reduced instead :100:
- Similar story for drawing cliffs. This code was duplicated for drawing `c2g.dxf` and `c3g.dxf` and so I created a function (diff looks a bit messy bcs of that, sorry!) and did the same optimization for reading the `dxf` files as for the curves.

Shaves of a second of each rendering step on my machine :rocket:

Also we should probably consider if we could store the temporary curves and cliffs in a more easy to read and write format instead of having to write and parse DXF files. Perhaps some relevant struct (one for multiple polylines and one for points) and then use [`postcard`](https://crates.io/crates/postcard) or [`bincode`](https://crates.io/crates/bincode) or similar to just serialize it efficiently to disk. Would make that part much faster and simpler in my opinion. We could provide a command similar to `internal2xyz` that can generate `dxf` from this internal format, or keep it as a config option to generate both :thinking: 