### PR TITLE
Statically link liblzma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ imageproc = { version = "0.25.0", default-features = false, features = [
 ] }
 
 las = { version = "0.9", features = ["laz"] }
+liblzma = { version = "*", features = ["static"] }
 rand = "0.9"
 rust-ini = "0.21"
 rustc-hash = "2.0"


### PR DESCRIPTION
Specify static linking to liblzma otherwise xz will be required at runtime, which isn't available by default on macOS.

With liblzma 4.2 and default features.

```
% otool -L pullauta | grep xz 
	/opt/homebrew/opt/xz/lib/liblzma.5.dylib (compatibility version 14.0.0, current version 14.1.0)
```

With liblzma and `features = ["static"]`, `otool -L` just lists standard macOS system libraries.

Closes #195 