### PR TITLE
feat: replace DXF files with internal binary format for storing and generating geometries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "serde",
+ "unty",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1175,8 @@ dependencies = [
 name = "pullauta"
 version = "2.8.0"
 dependencies = [
+ "anyhow",
+ "bincode",
  "env_logger",
  "image",
  "imageproc",
@@ -1174,6 +1186,7 @@ dependencies = [
  "rand 0.9.2",
  "rust-ini",
  "rustc-hash",
+ "serde",
  "shapefile",
  "skia-safe",
  "zip",
@@ -1726,6 +1739,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,7 @@ zip = { version = "4.3", default-features = false, features = [
 ], optional = true }
 log = "0.4"
 env_logger = "0.11"
+
+serde = { version = "1", default-features = false, features = ["derive"] }
+anyhow = "1"
+bincode = { version = "2.0", default-features = false, features = ["std", "serde"] }

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -7,7 +7,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::geometry::{BinaryDxf, Classification, Point2, Polylines};
+use crate::geometry::{BinaryDxf, Bounds, Classification, Point2, Polylines};
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
@@ -267,7 +267,7 @@ pub fn makecliffs(
         }
     }
 
-    let f2_dxf = BinaryDxf::new(xmin, xmax, ymin, ymax, f2_lines.into());
+    let f2_dxf = BinaryDxf::new(Bounds::new(xmin, xmax, ymin, ymax), f2_lines.into());
 
     // save binary file
     let f2 = fs
@@ -368,7 +368,7 @@ pub fn makecliffs(
         }
     }
 
-    let f3_dxf = BinaryDxf::new(xmin, xmax, ymin, ymax, f3_lines.into());
+    let f3_dxf = BinaryDxf::new(Bounds::new(xmin, xmax, ymin, ymax), f3_lines.into());
 
     // save binary file
     let f3 = fs

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -7,7 +7,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::geometry::{BinaryDxf, CliffClassification, Polylines};
+use crate::geometry::{BinaryDxf, CliffClassification, Point2, Polylines};
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
@@ -231,11 +231,11 @@ pub fn makecliffs(
 
                                     f2_lines.push(
                                         vec![
-                                            (
+                                            Point2::new(
                                                 (x0 + xt) / 2.0 + cliff_length * (y0 - yt) / dist,
                                                 (y0 + yt) / 2.0 - cliff_length * (x0 - xt) / dist,
                                             ),
-                                            (
+                                            Point2::new(
                                                 (x0 + xt) / 2.0 - cliff_length * (y0 - yt) / dist,
                                                 (y0 + yt) / 2.0 + cliff_length * (x0 - xt) / dist,
                                             ),
@@ -248,11 +248,11 @@ pub fn makecliffs(
                             if temp > limit2 && temp > (limit2 + (dist - limit2) * 0.85) {
                                 f3_lines.push(
                                     vec![
-                                        (
+                                        Point2::new(
                                             (x0 + xt) / 2.0 + cliff_length * (y0 - yt) / dist,
                                             (y0 + yt) / 2.0 - cliff_length * (x0 - xt) / dist,
                                         ),
-                                        (
+                                        Point2::new(
                                             (x0 + xt) / 2.0 - cliff_length * (y0 - yt) / dist,
                                             (y0 + yt) / 2.0 + cliff_length * (x0 - xt) / dist,
                                         ),
@@ -350,11 +350,11 @@ pub fn makecliffs(
                         if dist > 0.0 && temp > limit && temp > (limit + (dist - limit) * 0.85) {
                             f3_lines.push(
                                 vec![
-                                    (
+                                    Point2::new(
                                         (x0 + xt) / 2.0 + cliff_length * (y0 - yt) / dist,
                                         (y0 + yt) / 2.0 - cliff_length * (x0 - xt) / dist,
                                     ),
-                                    (
+                                    Point2::new(
                                         (x0 + xt) / 2.0 - cliff_length * (y0 - yt) / dist,
                                         (y0 + yt) / 2.0 + cliff_length * (x0 - xt) / dist,
                                     ),

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -7,7 +7,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::geometry::{BinaryDxf, CliffClassification, Point2, Polylines};
+use crate::geometry::{BinaryDxf, Classification, Point2, Polylines};
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
@@ -118,8 +118,8 @@ pub fn makecliffs(
     let w = ((xmax - xmin).floor() / 3.0) as usize;
     let h = ((ymax - ymin).floor() / 3.0) as usize;
 
-    let mut f2_lines = Polylines::<CliffClassification>::new();
-    let mut f3_lines = Polylines::<CliffClassification>::new();
+    let mut f2_lines = Polylines::new();
+    let mut f3_lines = Polylines::new();
 
     // temporary vector to reuse memory allocations
     let mut t = Vec::<(f64, f64, f64)>::new();
@@ -240,7 +240,7 @@ pub fn makecliffs(
                                                 (y0 + yt) / 2.0 + cliff_length * (x0 - xt) / dist,
                                             ),
                                         ],
-                                        CliffClassification::Cliff2,
+                                        Classification::Cliff2,
                                     );
                                 }
                             }
@@ -257,7 +257,7 @@ pub fn makecliffs(
                                             (y0 + yt) / 2.0 + cliff_length * (x0 - xt) / dist,
                                         ),
                                     ],
-                                    CliffClassification::Cliff3,
+                                    Classification::Cliff3,
                                 );
                             }
                         }
@@ -267,7 +267,7 @@ pub fn makecliffs(
         }
     }
 
-    let f2_dxf = BinaryDxf::<CliffClassification>::new(xmin, xmax, ymin, ymax, f2_lines.into());
+    let f2_dxf = BinaryDxf::new(xmin, xmax, ymin, ymax, f2_lines.into());
 
     // save binary file
     let f2 = fs
@@ -359,7 +359,7 @@ pub fn makecliffs(
                                         (y0 + yt) / 2.0 + cliff_length * (x0 - xt) / dist,
                                     ),
                                 ],
-                                CliffClassification::Cliff4,
+                                Classification::Cliff4,
                             );
                         }
                     }
@@ -368,7 +368,7 @@ pub fn makecliffs(
         }
     }
 
-    let f3_dxf = BinaryDxf::<CliffClassification>::new(xmin, xmax, ymin, ymax, f3_lines.into());
+    let f3_dxf = BinaryDxf::new(xmin, xmax, ymin, ymax, f3_lines.into());
 
     // save binary file
     let f3 = fs

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -5,7 +5,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::geometry::{BinaryDxf, ContourClassification, Polylines};
+use crate::geometry::{BinaryDxf, ContourClassification, Point2, Polylines};
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
@@ -513,7 +513,7 @@ pub fn heightmap2contours(
                     let x: f64 = x * size + xmin;
                     let y: f64 = y * size + ymin;
 
-                    Some((x, y))
+                    Some(Point2 { x, y })
                 })
                 .collect::<Vec<_>>(),
             ContourClassification::Contour,

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -5,7 +5,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::geometry::{BinaryDxf, ContourClassification, Point2, Polylines};
+use crate::geometry::{BinaryDxf, Classification, Point2, Polylines};
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
@@ -495,7 +495,7 @@ pub fn heightmap2contours(
 
     // convert the polylines to our internal binary dxf format
 
-    let mut lines = Polylines::<ContourClassification>::new();
+    let mut lines = Polylines::new();
     for polyline in polylines.into_iter() {
         lines.push(
             polyline
@@ -516,7 +516,7 @@ pub fn heightmap2contours(
                     Some(Point2 { x, y })
                 })
                 .collect::<Vec<_>>(),
-            ContourClassification::Contour,
+            Classification::Contour,
         );
     }
     let dxf = BinaryDxf::new(xmin, xmax, ymin, ymax, lines.into());

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -5,7 +5,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::geometry::{BinaryDxf, Classification, Point2, Polylines};
+use crate::geometry::{BinaryDxf, Bounds, Classification, Point2, Polylines};
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
@@ -516,10 +516,10 @@ pub fn heightmap2contours(
                     Some(Point2 { x, y })
                 })
                 .collect::<Vec<_>>(),
-            Classification::Contour,
+            Classification::ContourSimple,
         );
     }
-    let dxf = BinaryDxf::new(xmin, xmax, ymin, ymax, lines.into());
+    let dxf = BinaryDxf::new(Bounds::new(xmin, xmax, ymin, ymax), lines.into());
 
     // write to disk
     let f = fs

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -39,7 +39,7 @@ impl Point3 {
 
 /// A collection of points with associated classification. This classification is also used to put
 /// the DXF objects into separate layers.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Points {
     points: Vec<Point2>,
     classification: Vec<Classification>,
@@ -60,6 +60,7 @@ impl Points {
         }
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.points.len()
     }
@@ -74,14 +75,20 @@ impl Points {
     pub fn iter(&self) -> impl Iterator<Item = (&Point2, &Classification)> {
         self.points.iter().zip(self.classification.iter())
     }
+}
 
-    pub fn into_iter(self) -> impl Iterator<Item = (Point2, Classification)> {
+impl IntoIterator for Points {
+    type Item = (Point2, Classification);
+
+    type IntoIter = std::iter::Zip<std::vec::IntoIter<Point2>, std::vec::IntoIter<Classification>>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.points.into_iter().zip(self.classification)
     }
 }
 
 /// A collection polylines with associated classification.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Polylines<P, C> {
     polylines: Vec<Vec<P>>, // TODO: flatten to single vector?
     classification: Vec<C>,
@@ -100,16 +107,23 @@ impl<P, C> Polylines<P, C> {
         self.classification.push(class);
     }
 
-    pub fn into_iter(self) -> impl Iterator<Item = (Vec<P>, C)> {
-        self.polylines.into_iter().zip(self.classification)
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = (&Vec<P>, &C)> {
         self.polylines.iter().zip(self.classification.iter())
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.polylines.len()
+    }
+}
+
+impl<P, C> IntoIterator for Polylines<P, C> {
+    type Item = (Vec<P>, C);
+
+    type IntoIter = std::iter::Zip<std::vec::IntoIter<Vec<P>>, std::vec::IntoIter<C>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.polylines.into_iter().zip(self.classification)
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -36,13 +36,6 @@ impl<C> Points<C> {
     }
 }
 
-impl<C: ClassificationToLayer> Points<C> {
-    /// Write this collection of points to a DXF file.
-    pub fn to_dxf<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        todo!()
-    }
-}
-
 /// A collection polylines with associated classification.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Polylines<C> {
@@ -166,8 +159,26 @@ pub enum ContourClassification {
 impl ClassificationToLayer for ContourClassification {
     fn to_layer(&self) -> &str {
         match self {
-            ContourClassification::Contour => "cont",
+            Self::Contour => "cont",
         }
     }
 }
 
+/// Classification used for cliffs
+
+/// Classification used for contour generation
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum CliffClassification {
+    Cliff2,
+    Cliff3,
+    Cliff4,
+}
+impl ClassificationToLayer for CliffClassification {
+    fn to_layer(&self) -> &str {
+        match self {
+            Self::Cliff2 => "cliff2",
+            Self::Cliff3 => "cliff3",
+            Self::Cliff4 => "cliff4",
+        }
+    }
+}

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -54,8 +54,8 @@ impl Points {
     }
 
     /// Add a point to this collection.
-    pub fn push(&mut self, x: f64, y: f64, class: Classification) {
-        self.points.push(Point2::new(x, y));
+    pub fn push(&mut self, point: Point2, class: Classification) {
+        self.points.push(point);
         self.classification.push(class);
     }
 
@@ -193,8 +193,16 @@ impl BinaryDxf {
         )?;
 
         match &self.data {
-            Geometry::Points(_points) => {
-                todo!()
+            Geometry::Points(points) => {
+                for (point, class) in points.points.iter().zip(&points.classification) {
+                    let layer = class.to_layer();
+
+                    write!(
+                        writer,
+                        "POINT\r\n  8\r\n{layer}\r\n 10\r\n{}\r\n 20\r\n{}\r\n 50\r\n0\r\n  0\r\n",
+                        point.x, point.y
+                    )?;
+                }
             }
             Geometry::Polylines2(polylines) => {
                 for (polyline, class) in polylines.polylines.iter().zip(&polylines.classification) {
@@ -256,6 +264,12 @@ pub enum Classification {
     DepressionIntermed,
     DepressionIndexIntermed,
 
+    /// Used in dotknoll detections
+    Dotknoll,
+    Udepression,
+    UglyDotknoll,
+    UglyUdepression,
+
     /// Used for cliff generations
     Cliff2,
     Cliff3,
@@ -277,6 +291,11 @@ impl Classification {
             Self::DepressionIndex => "depression_index",
             Self::DepressionIntermed => "depression_intermed",
             Self::DepressionIndexIntermed => "depression_index_intermed",
+
+            Self::Dotknoll => "dotknoll",
+            Self::Udepression => "udepression",
+            Self::UglyDotknoll => "uglydotknoll",
+            Self::UglyUdepression => "uglyudepression",
 
             Self::Cliff2 => "cliff2",
             Self::Cliff3 => "cliff3",

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -60,7 +60,7 @@ impl Points {
     }
 
     /// Iterate over the points in this collection.
-    pub fn points(&self) -> impl Iterator<Item = (&Point2, &Classification)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Point2, &Classification)> {
         self.points.iter().zip(self.classification.iter())
     }
 }
@@ -248,7 +248,7 @@ impl BinaryDxf {
 }
 
 /// Classification used for contour generation
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Classification {
     /// Used in first contour generation step
     ContourSimple,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,0 +1,173 @@
+//! This mod contains structs for storing and loading different types of geometry, like Polylines
+//! and a list of Points.
+//!
+//! These types also have helpers for exporting them to DXF format.
+
+/// Needs to be implemented by any classification type that can be converted to a DXF layer name.
+pub trait ClassificationToLayer {
+    fn to_layer(&self) -> &str;
+}
+
+/// A collection of points with associated classification. This classification is also used to put
+/// the DXF objects into separate layers.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Points<C> {
+    points: Vec<(f64, f64)>,
+    classification: Vec<C>,
+}
+
+impl<C> Points<C> {
+    pub fn new() -> Self {
+        Self {
+            points: Vec::new(),
+            classification: Vec::new(),
+        }
+    }
+
+    /// Add a point to this collection.
+    pub fn push(&mut self, x: f64, y: f64, class: C) {
+        self.points.push((x, y));
+        self.classification.push(class);
+    }
+
+    /// Iterate over the points in this collection.
+    pub fn points(&self) -> impl Iterator<Item = (&(f64, f64), &C)> {
+        self.points.iter().zip(self.classification.iter())
+    }
+}
+
+impl<C: ClassificationToLayer> Points<C> {
+    /// Write this collection of points to a DXF file.
+    pub fn to_dxf<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        todo!()
+    }
+}
+
+/// A collection polylines with associated classification.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Polylines<C> {
+    polylines: Vec<Vec<(f64, f64)>>, // TODO: flatten to single vector?
+    classification: Vec<C>,
+}
+
+impl<C> Polylines<C> {
+    pub fn new() -> Self {
+        Self {
+            polylines: Vec::new(),
+            classification: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, polyline: Vec<(f64, f64)>, class: C) {
+        self.polylines.push(polyline);
+        self.classification.push(class);
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum Geometry<C> {
+    Points(Points<C>),
+    Polylines(Polylines<C>),
+}
+
+impl<C> From<Points<C>> for Geometry<C> {
+    fn from(points: Points<C>) -> Self {
+        Geometry::Points(points)
+    }
+}
+impl<C> From<Polylines<C>> for Geometry<C> {
+    fn from(polylines: Polylines<C>) -> Self {
+        Geometry::Polylines(polylines)
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct BinaryDxf<C> {
+    /// the version of the program that created this file, used to detect stale temp files
+    version: String,
+    xmin: f64,
+    xmax: f64,
+    ymin: f64,
+    ymax: f64,
+
+    data: Geometry<C>,
+}
+
+impl<C> BinaryDxf<C> {
+    pub fn new(xmin: f64, xmax: f64, ymin: f64, ymax: f64, data: Geometry<C>) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            xmin,
+            xmax,
+            ymin,
+            ymax,
+            data,
+        }
+    }
+}
+
+impl<C: serde::Serialize> BinaryDxf<C> {
+    /// Serialize this object to a writer.
+    pub fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+        crate::util::write_object(writer, self)
+    }
+}
+impl<C: serde::de::DeserializeOwned> BinaryDxf<C> {
+    /// Read this object from a reader. Returns an error if the version does not match.
+    pub fn from_reader<R: std::io::Read>(reader: &mut R) -> anyhow::Result<Self> {
+        let object: Self = crate::util::read_object(reader)?;
+        anyhow::ensure!(
+            object.version == env!("CARGO_PKG_VERSION"),
+            "Binary DXF file was created with another version, please remove and recreate"
+        );
+        Ok(object)
+    }
+}
+
+impl<C: ClassificationToLayer> BinaryDxf<C> {
+    /// Write this geometry to a DXF file.
+    pub fn to_dxf<W: std::io::Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+        write!(
+            writer,
+            "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{}\r\n 20\r\n{}\r\n  9\r\n$EXTMAX\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n",
+            self.xmin, self.ymin, self.xmax, self.ymax
+        )?;
+
+        match &self.data {
+            Geometry::Points(_points) => {
+                todo!()
+            }
+            Geometry::Polylines(polylines) => {
+                for (polyline, class) in polylines.polylines.iter().zip(&polylines.classification) {
+                    let layer = class.to_layer();
+                    write!(writer, "POLYLINE\r\n 66\r\n1\r\n  8\r\n{layer}\r\n  0\r\n")?;
+
+                    for &(x, y) in polyline {
+                        write!(
+                            writer,
+                            "VERTEX\r\n  8\r\n{layer}\r\n 10\r\n{x}\r\n 20\r\n{y}\r\n  0\r\n",
+                        )?;
+                    }
+                    write!(writer, "SEQEND\r\n  0\r\n")?;
+                }
+            }
+        }
+
+        writer.write_all("ENDSEC\r\n  0\r\nEOF\r\n".as_bytes())?;
+        Ok(())
+    }
+}
+
+/// Classification used for contour generation
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum ContourClassification {
+    Contour,
+}
+impl ClassificationToLayer for ContourClassification {
+    fn to_layer(&self) -> &str {
+        match self {
+            ContourClassification::Contour => "cont",
+        }
+    }
+}
+

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -55,6 +55,14 @@ impl<C> Polylines<C> {
         self.polylines.push(polyline);
         self.classification.push(class);
     }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (Vec<(f64, f64)>, C)> {
+        self.polylines.into_iter().zip(self.classification)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Vec<(f64, f64)>, &C)> {
+        self.polylines.iter().zip(self.classification.iter())
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -95,6 +103,14 @@ impl<C> BinaryDxf<C> {
             ymin,
             ymax,
             data,
+        }
+    }
+
+    /// Get the points in this geometry, or [`None`] if does not contain [`Polylines`] data.
+    pub fn take_polylines(self) -> Option<Polylines<C>> {
+        match self.data {
+            Geometry::Polylines(polylines) => Some(polylines),
+            Geometry::Points(_) => None,
         }
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -4,7 +4,7 @@
 //! These types also have helpers for exporting them to DXF format.
 
 /// A 2D point
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Point2 {
     /// The x coordinate of this point.
     pub x: f64,
@@ -20,7 +20,7 @@ impl Point2 {
 }
 
 /// A 3D point (eg. 2D + height)
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Point3 {
     /// The x coordinate of this point.
     pub x: f64,
@@ -53,6 +53,17 @@ impl Points {
         }
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            points: Vec::with_capacity(capacity),
+            classification: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.points.len()
+    }
+
     /// Add a point to this collection.
     pub fn push(&mut self, point: Point2, class: Classification) {
         self.points.push(point);
@@ -62,6 +73,10 @@ impl Points {
     /// Iterate over the points in this collection.
     pub fn iter(&self) -> impl Iterator<Item = (&Point2, &Classification)> {
         self.points.iter().zip(self.classification.iter())
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (Point2, Classification)> {
+        self.points.into_iter().zip(self.classification)
     }
 }
 
@@ -248,7 +263,7 @@ impl BinaryDxf {
 }
 
 /// Classification used for contour generation
-#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Classification {
     /// Used in first contour generation step
     ContourSimple,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -283,4 +283,54 @@ impl Classification {
             Self::Cliff4 => "cliff4",
         }
     }
+
+    pub fn is_contour(&self) -> bool {
+        matches!(
+            self,
+            Self::Contour | Self::ContourIndex | Self::ContourIntermed | Self::ContourIndexIntermed
+        )
+    }
+
+    pub fn is_depression(&self) -> bool {
+        matches!(
+            self,
+            Self::Depression
+                | Self::DepressionIndex
+                | Self::DepressionIntermed
+                | Self::DepressionIndexIntermed
+        )
+    }
+
+    pub fn is_index(&self) -> bool {
+        matches!(
+            self,
+            Self::ContourIndex
+                | Self::ContourIndexIntermed
+                | Self::DepressionIndex
+                | Self::DepressionIndexIntermed
+        )
+    }
+
+    pub fn is_intermed(&self) -> bool {
+        matches!(
+            self,
+            Self::ContourIntermed
+                | Self::ContourIndexIntermed
+                | Self::DepressionIntermed
+                | Self::DepressionIndexIntermed
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_classification_size_is_single_byte() {
+        assert_eq!(
+            std::mem::size_of::<super::Classification>(),
+            1,
+            "Classification should be a single byte"
+        );
+    }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -135,10 +135,10 @@ pub struct BinaryDxf {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Bounds {
-    xmin: f64,
-    xmax: f64,
-    ymin: f64,
-    ymax: f64,
+    pub xmin: f64,
+    pub xmax: f64,
+    pub ymin: f64,
+    pub ymax: f64,
 }
 
 impl Bounds {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,6 +6,8 @@ use std::{
 use fs::FileSystem;
 use heightmap::HeightMap;
 
+use crate::geometry::BinaryDxf;
+
 pub mod bytes;
 pub mod fs;
 pub mod heightmap;
@@ -40,5 +42,12 @@ pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io:
         panic!("Unknown internal file format: {input}");
     }
 
+    Ok(())
+}
+
+/// Helper for converting a binary DXF file to a regular DXF file.
+pub fn bin2dxf(fs: &impl FileSystem, input: &str, output: &str) -> anyhow::Result<()> {
+    let binary = BinaryDxf::from_reader(&mut BufReader::new(fs.open(input)?))?;
+    binary.to_dxf(&mut BufWriter::new(fs.create(output)?))?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cliffs;
 pub mod config;
 pub mod contours;
 pub mod crop;
+pub mod geometry;
 pub mod io;
 pub mod knolls;
 pub mod merge;

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,9 +156,16 @@ fn main() {
             return;
         }
 
-        let input = &args[0];
-        let output = &args[1];
-        pullauta::io::internal2xyz(&fs, input, output).unwrap();
+        pullauta::io::internal2xyz(&fs, &args[0], &args[1]).unwrap();
+        return;
+    }
+
+    if command == "bin2dxf" {
+        if args.len() < 2 {
+            info!("USAGE: bin2dxf [input file] [output file]");
+            return;
+        }
+        pullauta::io::bin2dxf(&fs, &args[0], &args[1]).unwrap();
         return;
     }
 
@@ -172,15 +179,18 @@ fn main() {
         return;
     }
 
-    if command == "dxfmerge" || command == "merge" {
+    if command == "dxfmerge" {
         pullauta::merge::dxfmerge(&fs, &config).unwrap();
-        if command == "merge" {
-            let mut scale = 1.0;
-            if !args.is_empty() {
-                scale = args[0].parse::<f64>().unwrap();
-            }
-            pullauta::merge::pngmergevege(&fs, &config, scale).unwrap();
+        return;
+    }
+
+    if command == "merge" {
+        let mut scale = 1.0;
+        if !args.is_empty() {
+            scale = args[0].parse::<f64>().unwrap();
         }
+        pullauta::merge::dxfmerge(&fs, &config).unwrap();
+        pullauta::merge::pngmergevege(&fs, &config, scale).unwrap();
         return;
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -625,10 +625,10 @@ pub fn smoothjoin(
 
     let mut heads1: HashMap<String, usize> = HashMap::default();
     let mut heads2: HashMap<String, usize> = HashMap::default();
-    let mut heads = Vec::<String>::new();
-    let mut tails = Vec::<String>::new();
-    let mut el_x = Vec::<Vec<f64>>::new();
-    let mut el_y = Vec::<Vec<f64>>::new();
+    let mut heads = Vec::<String>::with_capacity(input_lines.len());
+    let mut tails = Vec::<String>::with_capacity(input_lines.len());
+    let mut el_x = Vec::<Vec<f64>>::with_capacity(input_lines.len());
+    let mut el_y = Vec::<Vec<f64>>::with_capacity(input_lines.len());
 
     for (j, (line, _c)) in input_lines.iter().enumerate() {
         let first = line.first().unwrap();

--- a/src/process.rs
+++ b/src/process.rs
@@ -814,12 +814,12 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                 }
             }
 
-            let out2_path = PathBuf::from(format!("temp{thread}/out2.dxf"));
+            let out2_path = PathBuf::from(format!("temp{thread}/out2.dxf.bin"));
             if fs.exists(&out2_path) {
-                crop::polylinedxfcrop(
+                crop::polylinebindxfcrop(
                     fs,
                     &out2_path,
-                    Path::new(&format!("{batchoutfolder}/{laz}_contours.dxf")),
+                    Path::new(&format!("{batchoutfolder}/{laz}_contours.dxf.bin")),
                     minx,
                     miny,
                     maxx,
@@ -829,12 +829,12 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
             }
             let dxf_files = ["c2g", "c3g", "contours03", "detected", "formlines"];
             for dxf_file in dxf_files.iter() {
-                let dxf_path = PathBuf::from(format!("temp{thread}/{dxf_file}.dxf"));
+                let dxf_path = PathBuf::from(format!("temp{thread}/{dxf_file}.dxf.bin"));
                 if fs.exists(&dxf_path) {
-                    crop::polylinedxfcrop(
+                    crop::polylinebindxfcrop(
                         fs,
                         &dxf_path,
-                        Path::new(&format!("{batchoutfolder}/{laz}_{dxf_file}.dxf")),
+                        Path::new(&format!("{batchoutfolder}/{laz}_{dxf_file}.dxf.bin")),
                         minx,
                         miny,
                         maxx,
@@ -843,12 +843,12 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                     .unwrap();
                 }
             }
-            let dotknolls_file = PathBuf::from(format!("temp{thread}/dotknolls.dxf"));
+            let dotknolls_file = PathBuf::from(format!("temp{thread}/dotknolls.dxf.bin"));
             if fs.exists(&dotknolls_file) {
-                crop::pointdxfcrop(
+                crop::pointbindxfcrop(
                     fs,
                     &dotknolls_file,
-                    Path::new(&format!("{batchoutfolder}/{laz}_dotknolls.dxf")),
+                    Path::new(&format!("{batchoutfolder}/{laz}_dotknolls.dxf.bin")),
                     minx,
                     miny,
                     maxx,
@@ -858,12 +858,12 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
             }
         }
 
-        let basemap_file = PathBuf::from(format!("temp{thread}/basemap.dxf"));
+        let basemap_file = PathBuf::from(format!("temp{thread}/basemap.dxf.bin"));
         if fs.exists(&basemap_file) {
-            crop::polylinedxfcrop(
+            crop::polylinebindxfcrop(
                 fs,
                 &basemap_file,
-                Path::new(&format!("{batchoutfolder}/{laz}_basemap.dxf")),
+                Path::new(&format!("{batchoutfolder}/{laz}_basemap.dxf.bin")),
                 minx,
                 miny,
                 maxx,

--- a/src/process.rs
+++ b/src/process.rs
@@ -216,8 +216,7 @@ pub fn process_tile(
     .expect("contour generation failed");
     xyz_03.to_file(fs, tmpfolder.join("xyz_03.hmap")).unwrap();
 
-    if vegeonly || cliffsonly {
-    } else {
+    if !(vegeonly || cliffsonly) {
         contours::heightmap2contours(
             fs,
             tmpfolder,

--- a/src/render.rs
+++ b/src/render.rs
@@ -309,8 +309,8 @@ fn draw_cliffs(
 
         // scale and flip all points into pixel-space
         for p in line.iter_mut() {
-            p.0 = (p.0 - x0) * 600.0 / 254.0 / scalefactor;
-            p.1 = (y0 - p.1) * 600.0 / 254.0 / scalefactor;
+            p.x = (p.x - x0) * 600.0 / 254.0 / scalefactor;
+            p.y = (y0 - p.y) * 600.0 / 254.0 / scalefactor;
         }
 
         if line.first() != line.last() {
@@ -320,16 +320,16 @@ fn draw_cliffs(
                 continue;
             };
 
-            let dx = first.0 - last.0;
-            let dy = first.1 - last.1;
+            let dx = first.x - last.x;
+            let dy = first.y - last.y;
             let dist = (dx.powi(2) + dy.powi(2)).sqrt();
             if dist > 0.0 {
-                first.0 += dx / dist * 1.5;
-                first.1 += dy / dist * 1.5;
-                last.0 -= dx / dist * 1.5;
-                last.1 -= dy / dist * 1.5;
-                draw_filled_circle_mut(img, (first.0 as i32, first.1 as i32), 3, cliffcolor);
-                draw_filled_circle_mut(img, (last.0 as i32, last.1 as i32), 3, cliffcolor);
+                first.x += dx / dist * 1.5;
+                first.y += dy / dist * 1.5;
+                last.x -= dx / dist * 1.5;
+                last.y -= dy / dist * 1.5;
+                draw_filled_circle_mut(img, (first.x as i32, first.y as i32), 3, cliffcolor);
+                draw_filled_circle_mut(img, (last.x as i32, last.y as i32), 3, cliffcolor);
             }
         }
         for i in 1..line.len() {
@@ -338,12 +338,12 @@ fn draw_cliffs(
                     draw_line_segment_mut(
                         img,
                         (
-                            (line[i - 1].0 + (n as f64) - 3.0).floor() as f32,
-                            (line[i - 1].1 + (m as f64) - 3.0).floor() as f32,
+                            (line[i - 1].x + (n as f64) - 3.0).floor() as f32,
+                            (line[i - 1].y + (m as f64) - 3.0).floor() as f32,
                         ),
                         (
-                            (line[i].0 + (n as f64) - 3.0).floor() as f32,
-                            (line[i].1 + (m as f64) - 3.0).floor() as f32,
+                            (line[i].x + (n as f64) - 3.0).floor() as f32,
+                            (line[i].y + (m as f64) - 3.0).floor() as f32,
                         ),
                         cliffcolor,
                     )

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,11 +1,11 @@
 use crate::config::Config;
 use crate::geometry::BinaryDxf;
 use crate::geometry::Classification;
+use crate::geometry::Geometry;
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::vec2d::Vec2D;
-use anyhow::Context;
 use image::ImageBuffer;
 use image::Rgba;
 use imageproc::drawing::{draw_filled_circle_mut, draw_line_segment_mut};
@@ -291,9 +291,9 @@ fn draw_cliffs(
     let input = tmpfolder.join(file);
     let dxf = BinaryDxf::from_reader(&mut BufReader::new(fs.open(input)?))?;
 
-    let lines = dxf
-        .take_polylines()
-        .context("cliff data should contain polylines")?;
+    let Geometry::Polylines2(lines) = dxf.take_geometry() else {
+        return Err(anyhow::anyhow!("cliff data should contain polylines").into());
+    };
 
     for (mut line, class) in lines.into_iter() {
         // based on the layer we select the cliffcolor

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::geometry::BinaryDxf;
-use crate::geometry::CliffClassification;
+use crate::geometry::Classification;
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
@@ -289,7 +289,7 @@ fn draw_cliffs(
     let scalefactor = config.scalefactor;
 
     let input = tmpfolder.join(file);
-    let dxf = BinaryDxf::<CliffClassification>::from_reader(&mut BufReader::new(fs.open(input)?))?;
+    let dxf = BinaryDxf::from_reader(&mut BufReader::new(fs.open(input)?))?;
 
     let lines = dxf
         .take_polylines()
@@ -299,9 +299,10 @@ fn draw_cliffs(
         // based on the layer we select the cliffcolor
         let cliffcolor = if config.cliffdebug {
             match class {
-                CliffClassification::Cliff2 => Rgba([100, 0, 100, 255]),
-                CliffClassification::Cliff3 => Rgba([0, 100, 100, 255]),
-                CliffClassification::Cliff4 => Rgba([100, 100, 0, 255]),
+                Classification::Cliff2 => Rgba([100, 0, 100, 255]),
+                Classification::Cliff3 => Rgba([0, 100, 100, 255]),
+                Classification::Cliff4 => Rgba([100, 100, 0, 255]),
+                _ => Rgba([0, 0, 0, 255]), // black
             }
         } else {
             Rgba([0, 0, 0, 255]) // black

--- a/src/render.rs
+++ b/src/render.rs
@@ -515,7 +515,6 @@ pub fn draw_curves(
         fs.open(tmpfolder.join("out2.dxf.bin"))?,
     ))
     .expect("Unable to read out2.dxf.bin");
-    let input_bounds = input_dxf.bounds().clone(); // store the bounds for usage in formlines.dxf
     let Geometry::Polylines3(input_lines) = input_dxf.take_geometry() else {
         return Err(anyhow::anyhow!("out2.dxf.bin does not contain polylines").into());
     };

--- a/src/render.rs
+++ b/src/render.rs
@@ -508,23 +508,20 @@ pub fn draw_curves(
         fs.open(tmpfolder.join("out2.dxf.bin"))?,
     ))
     .expect("Unable to read out2.dxf.bin");
+    let bounds = input_dxf.bounds().clone();
     let Geometry::Polylines3(input_lines) = input_dxf.take_geometry() else {
         return Err(anyhow::anyhow!("out2.dxf.bin does not contain polylines").into());
     };
-
-    let input = &tmpfolder.join("out2.dxf");
-    let data = fs.read_to_string(input).expect("Can not read input file");
-    let mut data = data.split("POLYLINE").peekable();
 
     // only create the file if condition is met
     let mut fp = if formline == 2.0 && !nodepressions {
         let output = tmpfolder.join("formlines.dxf");
         let fp = fs.create(output).expect("Unable to create file");
         let mut fp = BufWriter::new(fp);
-        fp.write_all(
-            data.peek()
-                .expect("should have at least one element")
-                .as_bytes(),
+        write!(
+            &mut fp,
+            "  0\r\nSECTION\r\n  2\r\nHEADER\r\n  9\r\n$EXTMIN\r\n 10\r\n{}\r\n 20\r\n{}\r\n  9\r\n$EXTMAX\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nENDSEC\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n",
+            bounds.xmin, bounds.ymin, bounds.xmax, bounds.ymax
         )
         .expect("Could not write file");
 


### PR DESCRIPTION
As per the description in #197 , this PR introduces an internal binary data format for storing geometries (collection of points and lines) which were before stored as plain text-based DXF files :100: This makes creating, loading and processing these geometries substantially simpler and also centralizes all logic that generates the DXF format in the first place into a single `to_dxf` function. Thus it is easy to add more output formats in the future, if desired. This change also makes it possible to completely cache all geometries in-memory if so desirded which could speed up performance even more (no serialization/deserialization needed!)


This PR is currently marked as draft since there are a few things that need to be finalized:

- [ ] The original issue mentions that we should automatically export DXF files by default. I do see the point, but to be fair this will just degrade performance for those that just want the final image output. Since there is a lot of copying, moving and merging of these files when executing batch jobs, it is also not easy to keep track of when the _final_ conversion to DXF should be performed, and to process both DXF and the binary files feels like a waste of resources IMO. Instead, I propose the introduction of a command `bin2dxf` (which is already implemented), that can be executed on the files you want to convert into DXF. I have checked that the output DXF is practically identical to the previous output :100: 
- [ ] The `polylinedxfcrop` and `pointdxfcrop` functions have been kept for use in the similarly-named CLI commands. Should we keep them or can they also be removed / changed to work on the binary files instead?
- [ ] I need to convert the `merge::dxfmerge` function to work on the binary files. 
- [ ] I need to convert `render` to output `formlines.dxf` using the binary format.
- [ ] The different generated `txt` files in `merge::smoothjoin` could also be stored as binary files of some serialized object. This will be in a follow-up PR, but I would like to know if this is okay or if there are users that rely on the contents of these textfiles? :thinking: 