### PR TITLE
rafactor: always buffer I/O

### DIFF
--- a/src/crop.rs
+++ b/src/crop.rs
@@ -1,4 +1,3 @@
-use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 use crate::geometry::{BinaryDxf, Geometry, Points, Polylines};
@@ -19,7 +18,7 @@ pub fn polylinebindxfcrop(
     log::debug!("Cropping polylines in binary DXF file: {input:?} to {output:?}");
 
     // read input file
-    let input = BinaryDxf::from_reader(&mut BufReader::new(fs.open(input)?))?;
+    let input = BinaryDxf::from_reader(&mut fs.open(input)?)?;
     let bounds = input.bounds().clone();
 
     let output_lines = match input.take_geometry().swap_remove(0) {
@@ -34,11 +33,11 @@ pub fn polylinebindxfcrop(
 
     // write the output (TODO: should we populate the new bounds here or keep the old?)
     let out = BinaryDxf::new(bounds, vec![output_lines]);
-    out.to_writer(&mut BufWriter::new(fs.create(output)?))?;
+    out.to_writer(&mut fs.create(output)?)?;
 
     if output_dxf {
         // remove the .bin extension for the DXF output
-        out.to_dxf(&mut BufWriter::new(fs.create(output.with_extension(""))?))?;
+        out.to_dxf(&mut fs.create(output.with_extension(""))?)?;
     }
 
     Ok(())
@@ -109,7 +108,7 @@ pub fn pointbindxfcrop(
 ) -> anyhow::Result<()> {
     log::debug!("Cropping points in binary DXF file: {input:?} to {output:?}");
     // read input file
-    let input = BinaryDxf::from_reader(&mut BufReader::new(fs.open(input)?))?;
+    let input = BinaryDxf::from_reader(&mut fs.open(input)?)?;
 
     let bounds = input.bounds().clone();
     let Geometry::Points(points) = input.take_geometry().swap_remove(0) else {
@@ -126,11 +125,11 @@ pub fn pointbindxfcrop(
 
     // write the output (TODO: should we populate the new bounds here or keep the old?)
     let out = BinaryDxf::new(bounds, vec![output_points.into()]);
-    out.to_writer(&mut BufWriter::new(fs.create(output)?))?;
+    out.to_writer(&mut fs.create(output)?)?;
 
     if output_dxf {
         // remove the .bin extension for the DXF output
-        out.to_dxf(&mut BufWriter::new(fs.create(output.with_extension(""))?))?;
+        out.to_dxf(&mut fs.create(output.with_extension(""))?)?;
     }
 
     Ok(())

--- a/src/io/fs/local.rs
+++ b/src/io/fs/local.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use super::FileSystem;
@@ -30,12 +30,18 @@ impl FileSystem for LocalFileSystem {
         std::fs::read_to_string(path)
     }
 
-    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek + Send + 'static, io::Error> {
-        std::fs::File::open(path)
+    fn open(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<impl BufRead + Seek + Send + 'static, io::Error> {
+        Ok(BufReader::with_capacity(
+            crate::ONE_MEGABYTE,
+            std::fs::File::open(path)?,
+        ))
     }
 
     fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error> {
-        std::fs::File::create(path)
+        Ok(BufWriter::new(std::fs::File::create(path)?))
     }
 
     fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {

--- a/src/io/fs/local.rs
+++ b/src/io/fs/local.rs
@@ -41,7 +41,10 @@ impl FileSystem for LocalFileSystem {
     }
 
     fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error> {
-        Ok(BufWriter::new(std::fs::File::create(path)?))
+        Ok(BufWriter::with_capacity(
+            crate::ONE_MEGABYTE,
+            std::fs::File::create(path)?,
+        ))
     }
 
     fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Read, Seek, Write},
+    io::{self, BufRead, Seek, Write},
     path::{Path, PathBuf},
 };
 
@@ -17,10 +17,13 @@ pub trait FileSystem: std::fmt::Debug {
     /// Check if a file exists.
     fn exists(&self, path: impl AsRef<Path>) -> bool;
 
-    /// Open a file for reading.
-    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek + Send + 'static, io::Error>;
+    /// Open a file for reading. This is always Buffered.
+    fn open(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<impl BufRead + Seek + Send + 'static, io::Error>;
 
-    /// Open a file for writing.
+    /// Open a file for writing. This is always Buffered.
     fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error>;
 
     /// Read a file into a String.
@@ -43,9 +46,7 @@ pub trait FileSystem: std::fmt::Debug {
         &self,
         path: impl AsRef<Path>,
     ) -> Result<image::DynamicImage, image::error::ImageError> {
-        let mut reader = image::ImageReader::new(std::io::BufReader::new(
-            self.open(path).expect("Could not open file"),
-        ));
+        let mut reader = image::ImageReader::new(self.open(path).expect("Could not open file"));
         reader.set_format(image::ImageFormat::Png);
         reader.decode()
     }

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -50,9 +50,8 @@ impl HeightMap {
         fs: &impl FileSystem,
         path: P,
     ) -> std::io::Result<Self> {
-        let file = fs.open(path)?;
-        let mut reader = std::io::BufReader::new(file);
-        HeightMap::from_bytes(&mut reader)
+        let mut reader = fs.open(path)?;
+        Self::from_bytes(&mut reader)
     }
 
     /// Helper for easily writing a HeightMap to a file
@@ -61,9 +60,8 @@ impl HeightMap {
         fs: &impl FileSystem,
         path: P,
     ) -> std::io::Result<()> {
-        let file = fs.create(path)?;
-        let mut writer = std::io::BufWriter::new(file);
-        self.to_bytes(&mut writer)
+        let mut file = fs.create(path)?;
+        self.to_bytes(&mut file)
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    io::{BufReader, BufWriter, Write},
-    path::Path,
-};
+use std::{io::Write, path::Path};
 
 use fs::FileSystem;
 use heightmap::HeightMap;
@@ -16,8 +13,8 @@ pub mod xyz;
 /// Helper function to convert an internal xyz file to a regular xyz file.
 pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io::Result<()> {
     if input.ends_with(".xyz.bin") {
-        let mut reader = xyz::XyzInternalReader::new(BufReader::new(fs.open(Path::new(input))?))?;
-        let mut writer = BufWriter::new(fs.create(output)?);
+        let mut reader = xyz::XyzInternalReader::new(fs.open(Path::new(input))?)?;
+        let mut writer = fs.create(output)?;
 
         while let Some(record) = reader.next()? {
             writeln!(
@@ -33,7 +30,7 @@ pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io:
         }
     } else if input.ends_with(".hmap") {
         let hmap = HeightMap::from_file(fs, input)?;
-        let mut writer = BufWriter::new(fs.create(output)?);
+        let mut writer = fs.create(output)?;
 
         for (x, y, h) in hmap.iter() {
             writeln!(writer, "{x} {y} {h}")?;
@@ -47,7 +44,7 @@ pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io:
 
 /// Helper for converting a binary DXF file to a regular DXF file.
 pub fn bin2dxf(fs: &impl FileSystem, input: &str, output: &str) -> anyhow::Result<()> {
-    let binary = BinaryDxf::from_reader(&mut BufReader::new(fs.open(input)?))?;
-    binary.to_dxf(&mut BufWriter::new(fs.create(output)?))?;
+    let binary = BinaryDxf::from_reader(&mut fs.open(input)?)?;
+    binary.to_dxf(&mut fs.create(output)?)?;
     Ok(())
 }

--- a/src/shapefile/render.rs
+++ b/src/shapefile/render.rs
@@ -1,6 +1,5 @@
 use std::{
     error::Error,
-    io::BufReader,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -65,10 +64,10 @@ pub fn render(
     let y0 = d[5].trim().parse::<f64>().unwrap();
     // let resvege = d[0].trim().parse::<f64>().unwrap();
 
-    let mut img_reader = image::ImageReader::new(BufReader::new(
+    let mut img_reader = image::ImageReader::new(
         fs.open(tmpfolder.join("vegetation.png"))
             .expect("Opening vegetation image failed"),
-    ));
+    );
     img_reader.set_format(image::ImageFormat::Png);
     img_reader.no_limits();
     let img = img_reader.decode().unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    io::{self, BufRead, BufReader},
+    io::{self, BufRead},
     path::Path,
     time::Instant,
 };
@@ -24,8 +24,7 @@ where
     debug!("Reading lines from {filename:?}");
     let start = Instant::now();
 
-    let file = fs.open(filename)?;
-    let mut reader = BufReader::new(file);
+    let mut reader = fs.open(filename)?;
 
     let mut line_buffer = String::new();
     let mut line_count: u32 = 0;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -5,7 +5,7 @@ use imageproc::rect::Rect;
 use log::info;
 use std::error::Error;
 use std::f32::consts::SQRT_2;
-use std::io::{BufReader, BufWriter, Write};
+use std::io::Write;
 use std::path::Path;
 
 use crate::config::{Config, Zone};
@@ -23,7 +23,7 @@ pub fn makevege(
     info!("Generating vegetation...");
 
     let heightmap_in = tmpfolder.join("xyz2.hmap");
-    let mut reader = BufReader::new(fs.open(heightmap_in)?);
+    let mut reader = fs.open(heightmap_in)?;
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
     // in world coordinates
@@ -76,10 +76,7 @@ pub fn makevege(
     let mut noyhit = Vec2D::new(w_3, h_3, 0_u32); // 3.0
 
     let mut i = 0;
-    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
-        crate::ONE_MEGABYTE,
-        fs.open(&xyz_file_in)?,
-    ))?;
+    let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
     while let Some(r) = reader.next()? {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
@@ -141,10 +138,7 @@ pub fn makevege(
     let mut ug = Vec2D::new(w_block_step, h_block_step, UggItem::default()); // block / step
 
     let mut i = 0;
-    let mut reader = XyzInternalReader::new(BufReader::with_capacity(
-        crate::ONE_MEGABYTE,
-        fs.open(&xyz_file_in)?,
-    ))?;
+    let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
     while let Some(r) = reader.next()? {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
@@ -376,20 +370,18 @@ pub fn makevege(
     }
     imgye2
         .write_to(
-            &mut BufWriter::new(
-                fs.create(tmpfolder.join("yellow.png"))
-                    .expect("error saving png"),
-            ),
+            &mut fs
+                .create(tmpfolder.join("yellow.png"))
+                .expect("error saving png"),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
 
     imggr1
         .write_to(
-            &mut BufWriter::new(
-                fs.create(tmpfolder.join("greens.png"))
-                    .expect("error saving png"),
-            ),
+            &mut fs
+                .create(tmpfolder.join("greens.png"))
+                .expect("error saving png"),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
@@ -398,10 +390,9 @@ pub fn makevege(
     image::imageops::overlay(&mut img, &DynamicImage::ImageRgba8(imgye2), 0, 0);
 
     img.write_to(
-        &mut BufWriter::new(
-            fs.create(tmpfolder.join("vegetation.png"))
-                .expect("error saving png"),
-        ),
+        &mut fs
+            .create(tmpfolder.join("vegetation.png"))
+            .expect("error saving png"),
         image::ImageFormat::Png,
     )
     .expect("could not save output png");
@@ -431,10 +422,9 @@ pub fn makevege(
 
         g_img
             .write_to(
-                &mut BufWriter::new(
-                    fs.create(tmpfolder.join("greens_bit.png"))
-                        .expect("error saving png"),
-                ),
+                &mut fs
+                    .create(tmpfolder.join("greens_bit.png"))
+                    .expect("error saving png"),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -455,10 +445,9 @@ pub fn makevege(
 
         y_img
             .write_to(
-                &mut BufWriter::new(
-                    fs.create(tmpfolder.join("yellow_bit.png"))
-                        .expect("error saving png"),
-                ),
+                &mut fs
+                    .create(tmpfolder.join("yellow_bit.png"))
+                    .expect("error saving png"),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -469,10 +458,9 @@ pub fn makevege(
 
         img_bit
             .write_to(
-                &mut BufWriter::new(
-                    fs.create(tmpfolder.join("vegetation_bit.png"))
-                        .expect("error saving png"),
-                ),
+                &mut fs
+                    .create(tmpfolder.join("vegetation_bit.png"))
+                    .expect("error saving png"),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -484,10 +472,7 @@ pub fn makevege(
     let buildings = config.buildings;
     let water = config.water;
     if buildings > 0 || water > 0 {
-        let mut reader = XyzInternalReader::new(BufReader::with_capacity(
-            crate::ONE_MEGABYTE,
-            fs.open(&xyz_file_in)?,
-        ))?;
+        let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
         while let Some(r) = reader.next()? {
             let (x, y) = (r.x, r.y);
             let c: u8 = r.classification;
@@ -521,10 +506,9 @@ pub fn makevege(
 
     imgwater
         .write_to(
-            &mut BufWriter::new(
-                fs.create(tmpfolder.join("blueblack.png"))
-                    .expect("error saving png"),
-            ),
+            &mut fs
+                .create(tmpfolder.join("blueblack.png"))
+                .expect("error saving png"),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
@@ -665,10 +649,9 @@ pub fn makevege(
     }
     imgug
         .write_to(
-            &mut BufWriter::new(
-                fs.create(tmpfolder.join("undergrowth.png"))
-                    .expect("error saving png"),
-            ),
+            &mut fs
+                .create(tmpfolder.join("undergrowth.png"))
+                .expect("error saving png"),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
@@ -677,18 +660,16 @@ pub fn makevege(
 
     img_ug_bit_b
         .write_to(
-            &mut BufWriter::new(
-                fs.create(tmpfolder.join("undergrowth_bit.png"))
-                    .expect("error saving png"),
-            ),
+            &mut fs
+                .create(tmpfolder.join("undergrowth_bit.png"))
+                .expect("error saving png"),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
 
-    let mut writer = BufWriter::new(
-        fs.create(tmpfolder.join("undergrowth.pgw"))
-            .expect("cannot create pgw file"),
-    );
+    let mut writer = fs
+        .create(tmpfolder.join("undergrowth.pgw"))
+        .expect("cannot create pgw file");
     write!(
         &mut writer,
         "{}\r\n0.0\r\n0.0\r\n{}\r\n{}\r\n{}\r\n",
@@ -699,10 +680,9 @@ pub fn makevege(
     )
     .expect("Cannot write pgw file");
 
-    let mut writer = BufWriter::new(
-        fs.create(tmpfolder.join("vegetation.pgw"))
-            .expect("cannot create pgw file"),
-    );
+    let mut writer = fs
+        .create(tmpfolder.join("vegetation.pgw"))
+        .expect("cannot create pgw file");
     write!(
         &mut writer,
         "1.0\r\n0.0\r\n0.0\r\n-1.0\r\n{xmin}\r\n{ymax}\r\n"


### PR DESCRIPTION
REmoves explicit use of `BufReader` and `BufWriter` and does the buffering directly in the file-system layer instead. This avoids some double-buffering when using the in-memory file system option. Also increased the write buffer size to `1MB` from the default `8kB`. On my machine it gives some nice speedups, especially when writing the `.xyz.bin` file with all the LAZ data :100: 