### PR TITLE
refactor!: store `dotknolls.txt` in binary format

### DIFF
--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -10,7 +10,17 @@ use crate::geometry::{BinaryDxf, Bounds, Classification, Geometry, Point2, Point
 use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
-use crate::util::read_lines_no_alloc;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Dotknolls {
+    pub dotknolls: Vec<Dotknoll>,
+}
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Dotknoll {
+    pub x: f64,
+    pub y: f64,
+    pub is_knoll: bool,
+}
 
 pub fn dotknolls(
     fs: &impl FileSystem,
@@ -63,44 +73,40 @@ pub fn dotknolls(
 
     let mut dotknoll_points = Points::new();
 
-    let input = tmpfolder.join("dotknolls.txt");
-    read_lines_no_alloc(fs, input, |line| {
-        let parts = line.split(' ');
-        let r = parts.collect::<Vec<&str>>();
-        if r.len() >= 3 {
-            let depression: bool = r[0] == "1";
-            let x: f64 = r[1].parse::<f64>().unwrap();
-            let y: f64 = r[2].parse::<f64>().unwrap();
-            let mut ok = true;
-            let mut i = (x - xstart) / scalefactor - 3.0;
-            while i < (x - xstart) / scalefactor + 4.0 && ok {
-                let mut j = (y - ystart) / scalefactor - 3.0;
-                while j < (y - ystart) / scalefactor + 4.0 && ok {
-                    if (i as u32) >= im.width() || (j as u32) >= im.height() {
-                        ok = false;
-                        break;
-                    }
-                    let pix = im.get_pixel(i as u32, j as u32);
-                    if pix[0] == 0 {
-                        ok = false;
-                        break;
-                    }
-                    j += 1.0;
+    let dotknolls: Dotknolls =
+        crate::util::read_object(&mut fs.open(tmpfolder.join("dotknolls.bin"))?)?;
+
+    for dot in dotknolls.dotknolls {
+        let Dotknoll { x, y, is_knoll } = dot;
+
+        let mut ok = true;
+        let mut i = (x - xstart) / scalefactor - 3.0;
+        while i < (x - xstart) / scalefactor + 4.0 && ok {
+            let mut j = (y - ystart) / scalefactor - 3.0;
+            while j < (y - ystart) / scalefactor + 4.0 && ok {
+                if (i as u32) >= im.width() || (j as u32) >= im.height() {
+                    ok = false;
+                    break;
                 }
-                i += 1.0;
+                let pix = im.get_pixel(i as u32, j as u32);
+                if pix[0] == 0 {
+                    ok = false;
+                    break;
+                }
+                j += 1.0;
             }
-
-            let layer2 = match (ok, depression) {
-                (true, true) => Classification::Dotknoll,
-                (true, false) => Classification::Udepression,
-                (false, true) => Classification::UglyDotknoll,
-                (false, false) => Classification::UglyUdepression,
-            };
-
-            dotknoll_points.push(Point2::new(x, y), layer2);
+            i += 1.0;
         }
-    })
-    .expect("Could not read file");
+
+        let layer2 = match (ok, is_knoll) {
+            (true, true) => Classification::Dotknoll,
+            (true, false) => Classification::Udepression,
+            (false, true) => Classification::UglyDotknoll,
+            (false, false) => Classification::UglyUdepression,
+        };
+
+        dotknoll_points.push(Point2::new(x, y), layer2);
+    }
 
     let dxf = BinaryDxf::new(
         Bounds::new(xstart, xmax * size + xstart, ystart, ymax * size + ystart),

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -400,8 +400,7 @@ pub fn smoothjoin(
     let depr_output = tmpfolder.join("depressions.txt");
     let mut depr_fp = fs.create(depr_output).expect("Unable to create file");
 
-    let dotknoll_output = tmpfolder.join("dotknolls.txt");
-    let mut dotknoll_fp = fs.create(dotknoll_output).expect("Unable to create file");
+    let mut dotknolls = Vec::new();
 
     let knollhead_output = tmpfolder.join("knollheads.txt");
     let mut knollhead_fp = fs.create(knollhead_output).expect("Unable to create file");
@@ -686,8 +685,13 @@ pub fn smoothjoin(
                 }
                 x_avg /= (el_x_len - 1) as f64;
                 y_avg /= (el_x_len - 1) as f64;
-                write!(&mut dotknoll_fp, "{depression} {x_avg} {y_avg}\r\n")
-                    .expect("Unable to write to file");
+
+                dotknolls.push(super::knolls::Dotknoll {
+                    x: x_avg,
+                    y: y_avg,
+                    is_knoll: depression == 1,
+                });
+
                 skip = true;
             }
 
@@ -899,6 +903,11 @@ pub fn smoothjoin(
             } // -- if not dotkoll
         }
     }
+
+    crate::util::write_object(
+        &mut fs.create(tmpfolder.join("dotknolls.bin"))?,
+        &super::knolls::Dotknolls { dotknolls },
+    )?;
 
     let out2_dxf = BinaryDxf::new(input_bounds, vec![out2_lines.into()]);
 


### PR DESCRIPTION
Store the `dotknolls.txt` as a serialized object instead of in a textfile (kinda breaking change if anyone was using the contents of this file for some post-processing). The other two files `depressions.txt` and `knollheads.txt` are never read anywhere. Should it be considered as final output and left intact or should we remove them completely? :thinking: 