### PR TITLE
feat!: store height as `f32`, more efficient reading / writing using `bytemuck`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,20 @@ name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -1177,6 +1191,7 @@ version = "2.9.3"
 dependencies = [
  "anyhow",
  "bincode",
+ "bytemuck",
  "env_logger",
  "image",
  "imageproc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,5 @@ env_logger = "0.11"
 serde = { version = "1", default-features = false, features = ["derive"] }
 anyhow = "1"
 bincode = { version = "2.0", default-features = false, features = ["std", "serde"] }
+
+bytemuck = { version = "1.23", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Then download the latest code at https://github.com/karttapullautin/karttapullau
     cargo build --release
 
 The `pullauta` binary will be accessible in the `target/release/` directory. You can proceed and copy it to your desired directory.
+For maximum performance, it is recommended to compile targeting the native cpu by specifying the `target-cpu` flag. This makes sure that any instruction set extensions such as SIMD and FMA are used. This includes if your processor supports AVX, AVX2 and AVX512 (and NEON on ARM targets) as 
+the default release binaries are compiled without these enabled to be as portable as possible. If you have a relatively recent CPU (eg. Intel `skylake` or later) you should instead compile like this:
+
+    RUSTFLAGS="-C target-cpu=native" cargo build --release
+
 
 ### Converting a LiDAR file
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -36,7 +36,7 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
     let xyz_file_in = tmpfolder.join("xyztemp.xyz.bin");
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?).unwrap();
     while let Some(r) = reader.next().unwrap() {
-        let (x, y, h) = (r.x, r.y, r.z);
+        let (x, y, h) = (r.x, r.y, r.z as f64);
         let r3 = r.classification;
         let r4 = r.number_of_returns;
         let r5 = r.return_number;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -35,8 +35,8 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz.bin");
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?).unwrap();
-    while let Some(r) = reader.next_chunk().unwrap() {
-        for r in r {
+    while let Some(chunk) = reader.next_chunk().unwrap() {
+        for r in chunk {
             let (x, y, h) = (r.x, r.y, r.z as f64);
             let r3 = r.classification;
             let r4 = r.number_of_returns;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -35,35 +35,41 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz.bin");
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?).unwrap();
-    while let Some(r) = reader.next().unwrap() {
-        let (x, y, h) = (r.x, r.y, r.z as f64);
-        let r3 = r.classification;
-        let r4 = r.number_of_returns;
-        let r5 = r.return_number;
+    while let Some(r) = reader.next_chunk().unwrap() {
+        for r in r {
+            let (x, y, h) = (r.x, r.y, r.z as f64);
+            let r3 = r.classification;
+            let r4 = r.number_of_returns;
+            let r5 = r.return_number;
 
-        let xx = ((x - xstartxyz) / size).floor() as u64;
-        let yy = ((y - ystartxyz) / size).floor() as u64;
-        if r3 != 2 && r3 != 9 && r4 == 1 && r5 == 1 && h - *xyz.get(&(xx, yy)).unwrap_or(&0.0) > 2.0
-        {
-            draw_filled_rect_mut(
-                &mut img,
-                Rect::at(
-                    (x - xstartxyz - 1.0) as i32,
-                    (ystartxyz + 2.0 * ymax as f64 - y - 1.0) as i32,
-                )
-                .of_size(3, 3),
-                black,
-            );
-        } else {
-            draw_filled_rect_mut(
-                &mut img2,
-                Rect::at(
-                    (x - xstartxyz - 1.0) as i32,
-                    (ystartxyz + 2.0 * ymax as f64 - y - 1.0) as i32,
-                )
-                .of_size(3, 3),
-                white,
-            );
+            let xx = ((x - xstartxyz) / size).floor() as u64;
+            let yy = ((y - ystartxyz) / size).floor() as u64;
+            if r3 != 2
+                && r3 != 9
+                && r4 == 1
+                && r5 == 1
+                && h - *xyz.get(&(xx, yy)).unwrap_or(&0.0) > 2.0
+            {
+                draw_filled_rect_mut(
+                    &mut img,
+                    Rect::at(
+                        (x - xstartxyz - 1.0) as i32,
+                        (ystartxyz + 2.0 * ymax as f64 - y - 1.0) as i32,
+                    )
+                    .of_size(3, 3),
+                    black,
+                );
+            } else {
+                draw_filled_rect_mut(
+                    &mut img2,
+                    Rect::at(
+                        (x - xstartxyz - 1.0) as i32,
+                        (ystartxyz + 2.0 * ymax as f64 - y - 1.0) as i32,
+                    )
+                    .of_size(3, 3),
+                    white,
+                );
+            }
         }
     }
 

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -95,17 +95,19 @@ pub fn makecliffs(
     let randdist = rand::distr::Bernoulli::new(cliff_thin).unwrap();
 
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next()? {
-        if cliff_thin == 1.0 || rng.sample(randdist) {
-            let (x, y, h) = (r.x, r.y, r.z as f64);
-            let r3 = r.classification;
+    while let Some(r) = reader.next_chunk()? {
+        for r in r {
+            if cliff_thin == 1.0 || rng.sample(randdist) {
+                let (x, y, h) = (r.x, r.y, r.z as f64);
+                let r3 = r.classification;
 
-            if r3 == 2 {
-                list_alt[(
-                    ((x - xmin).floor() / 3.0) as usize,
-                    ((y - ymin).floor() / 3.0) as usize,
-                )]
-                    .push((x, y, h));
+                if r3 == 2 {
+                    list_alt[(
+                        ((x - xmin).floor() / 3.0) as usize,
+                        ((y - ymin).floor() / 3.0) as usize,
+                    )]
+                        .push((x, y, h));
+                }
             }
         }
     }

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -95,8 +95,8 @@ pub fn makecliffs(
     let randdist = rand::distr::Bernoulli::new(cliff_thin).unwrap();
 
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next_chunk()? {
-        for r in r {
+    while let Some(chunk) = reader.next_chunk()? {
+        for r in chunk {
             if cliff_thin == 1.0 || rng.sample(randdist) {
                 let (x, y, h) = (r.x, r.y, r.z as f64);
                 let r3 = r.classification;

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -97,7 +97,7 @@ pub fn makecliffs(
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
     while let Some(r) = reader.next()? {
         if cliff_thin == 1.0 || rng.sample(randdist) {
-            let (x, y, h) = (r.x, r.y, r.z);
+            let (x, y, h) = (r.x, r.y, r.z as f64);
             let r3 = r.classification;
 
             if r3 == 2 {

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -35,33 +35,35 @@ pub fn xyz2heightmap(
 
     let xyz_file_in = tmpfolder.join(xyzfilein);
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next()? {
-        let x: f64 = r.x;
-        let y: f64 = r.y;
-        let h: f64 = r.z as f64;
+    while let Some(r) = reader.next_chunk()? {
+        for r in r {
+            let x: f64 = r.x;
+            let y: f64 = r.y;
+            let h: f64 = r.z as f64;
 
-        if xmin > x {
-            xmin = x;
-        }
+            if xmin > x {
+                xmin = x;
+            }
 
-        if xmax < x {
-            xmax = x;
-        }
+            if xmax < x {
+                xmax = x;
+            }
 
-        if ymin > y {
-            ymin = y;
-        }
+            if ymin > y {
+                ymin = y;
+            }
 
-        if ymax < y {
-            ymax = y;
-        }
+            if ymax < y {
+                ymax = y;
+            }
 
-        if hmin > h {
-            hmin = h;
-        }
+            if hmin > h {
+                hmin = h;
+            }
 
-        if hmax < h {
-            hmax = h;
+            if hmax < h {
+                hmax = h;
+            }
         }
     }
     drop(reader);
@@ -76,18 +78,20 @@ pub fn xyz2heightmap(
     let mut list_alt = Vec2D::new(w + 2, h + 2, (0f64, 0usize));
 
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next()? {
-        if r.classification == 2 || r.classification == water_class {
-            let x: f64 = r.x;
-            let y: f64 = r.y;
-            let h: f64 = r.z as f64;
+    while let Some(r) = reader.next_chunk()? {
+        for r in r {
+            if r.classification == 2 || r.classification == water_class {
+                let x: f64 = r.x;
+                let y: f64 = r.y;
+                let h: f64 = r.z as f64;
 
-            let idx_x = ((x - xmin).floor() / 2.0 / scalefactor) as usize;
-            let idx_y = ((y - ymin).floor() / 2.0 / scalefactor) as usize;
+                let idx_x = ((x - xmin).floor() / 2.0 / scalefactor) as usize;
+                let idx_y = ((y - ymin).floor() / 2.0 / scalefactor) as usize;
 
-            let (sum, count) = &mut list_alt[(idx_x, idx_y)];
-            *sum += h;
-            *count += 1;
+                let (sum, count) = &mut list_alt[(idx_x, idx_y)];
+                *sum += h;
+                *count += 1;
+            }
         }
     }
 

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -35,8 +35,8 @@ pub fn xyz2heightmap(
 
     let xyz_file_in = tmpfolder.join(xyzfilein);
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next_chunk()? {
-        for r in r {
+    while let Some(chunk) = reader.next_chunk()? {
+        for r in chunk {
             let x: f64 = r.x;
             let y: f64 = r.y;
             let h: f64 = r.z as f64;
@@ -78,8 +78,8 @@ pub fn xyz2heightmap(
     let mut list_alt = Vec2D::new(w + 2, h + 2, (0f64, 0usize));
 
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next_chunk()? {
-        for r in r {
+    while let Some(chunk) = reader.next_chunk()? {
+        for r in chunk {
             if r.classification == 2 || r.classification == water_class {
                 let x: f64 = r.x;
                 let y: f64 = r.y;

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -38,7 +38,7 @@ pub fn xyz2heightmap(
     while let Some(r) = reader.next()? {
         let x: f64 = r.x;
         let y: f64 = r.y;
-        let h: f64 = r.z;
+        let h: f64 = r.z as f64;
 
         if xmin > x {
             xmin = x;
@@ -80,7 +80,7 @@ pub fn xyz2heightmap(
         if r.classification == 2 || r.classification == water_class {
             let x: f64 = r.x;
             let y: f64 = r.y;
-            let h: f64 = r.z;
+            let h: f64 = r.z as f64;
 
             let idx_x = ((x - xmin).floor() / 2.0 / scalefactor) as usize;
             let idx_y = ((y - ymin).floor() / 2.0 / scalefactor) as usize;

--- a/src/io/bytes.rs
+++ b/src/io/bytes.rs
@@ -19,6 +19,18 @@ impl FromToBytes for f64 {
     }
 }
 
+impl FromToBytes for f32 {
+    fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut buff = [0; 4];
+        reader.read_exact(&mut buff)?;
+        Ok(f32::from_ne_bytes(buff))
+    }
+
+    fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_all(&self.to_ne_bytes())
+    }
+}
+
 impl FromToBytes for usize {
     fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let mut buff = [0; usize::BITS as usize / 8];

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -16,17 +16,19 @@ pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io:
         let mut reader = xyz::XyzInternalReader::new(fs.open(Path::new(input))?)?;
         let mut writer = fs.create(output)?;
 
-        while let Some(record) = reader.next()? {
-            writeln!(
-                writer,
-                "{} {} {} {} {} {}",
-                record.x,
-                record.y,
-                record.z,
-                record.classification,
-                record.number_of_returns,
-                record.return_number
-            )?;
+        while let Some(record) = reader.next_chunk()? {
+            for record in record {
+                writeln!(
+                    writer,
+                    "{} {} {} {} {} {}",
+                    record.x,
+                    record.y,
+                    record.z,
+                    record.classification,
+                    record.number_of_returns,
+                    record.return_number
+                )?;
+            }
         }
     } else if input.ends_with(".hmap") {
         let hmap = HeightMap::from_file(fs, input)?;

--- a/src/io/xyz.rs
+++ b/src/io/xyz.rs
@@ -227,9 +227,12 @@ mod test {
         let data = writer.finish().unwrap().into_inner();
         let cursor = Cursor::new(data);
         let mut reader = super::XyzInternalReader::new(cursor).unwrap();
-        assert_eq!(reader.next_chunk().unwrap().unwrap(), &[record]);
-        assert_eq!(reader.next_chunk().unwrap().unwrap(), &[record]);
-        assert_eq!(reader.next_chunk().unwrap().unwrap(), &[record]);
+        let chunk = reader.next_chunk().unwrap().unwrap();
+
+        assert_eq!(chunk.len(), 3);
+        assert_eq!(chunk[0], record);
+        assert_eq!(chunk[1], record);
+        assert_eq!(chunk[2], record);
         assert_eq!(reader.next_chunk().unwrap(), None);
     }
 }

--- a/src/io/xyz.rs
+++ b/src/io/xyz.rs
@@ -96,10 +96,13 @@ impl<W: Write + Seek> XyzInternalWriter<W> {
         if let Some(start) = self.start {
             let elapsed = start.elapsed();
             debug!(
-                "Wrote {} records in {:.2?} ({:.2?}/record)",
+                "Wrote {} records in {:.2?} ({:.2?}/record, {:.3}M records/s, {:.2}MB/s)",
                 self.records_written,
                 elapsed,
                 elapsed / self.records_written as u32,
+                self.records_written as f64 / (10e6 * elapsed.as_secs_f64()),
+                self.records_written as f64 * size_of::<XyzRecord>() as f64
+                    / (1024.0 * 1024.0 * elapsed.as_secs_f64()),
             );
         }
         Ok(inner)
@@ -152,10 +155,13 @@ impl<R: Read> XyzInternalReader<R> {
             if let Some(start) = self.start {
                 let elapsed = start.elapsed();
                 debug!(
-                    "Read {} records in {:.2?} ({:.2?}/record)",
+                    "Read {} records in {:.2?} ({:.2?}/record, {:.3}M records/s, {:.2}MB/s)",
                     self.records_read,
                     elapsed,
                     elapsed / self.records_read as u32,
+                    self.records_read as f64 / (10e6 * elapsed.as_secs_f64()),
+                    self.records_read as f64 * size_of::<XyzRecord>() as f64
+                        / (1024.0 * 1024.0 * elapsed.as_secs_f64()),
                 );
             }
 

--- a/src/io/xyz.rs
+++ b/src/io/xyz.rs
@@ -62,6 +62,10 @@ impl<W: Write + Seek> XyzInternalWriter<W> {
             .as_mut()
             .ok_or_else(|| std::io::Error::other("writer has already been finished"))?;
 
+        if records.is_empty() {
+            return Ok(()); // nothing to write
+        }
+
         // write the header (format + length) on the first write
         if self.records_written == 0 {
             self.start = Some(Instant::now());

--- a/src/io/xyz.rs
+++ b/src/io/xyz.rs
@@ -10,21 +10,23 @@ use log::debug;
 const XYZ_MAGIC: &[u8] = b"XYZB";
 
 /// A single record of an observed laser data point needed by the algorithms.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct XyzRecord {
     pub x: f64,
     pub y: f64,
-    pub z: f64,
+    pub z: f32,
     pub classification: u8,
     pub number_of_returns: u8,
     pub return_number: u8,
+    // padding bytes to make the struct exactly 24 bytes long
+    pub _padding: u8,
 }
 
 impl FromToBytes for XyzRecord {
     fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let x = f64::from_bytes(reader)?;
         let y = f64::from_bytes(reader)?;
-        let z = f64::from_bytes(reader)?;
+        let z = f32::from_bytes(reader)?;
 
         let mut buff = [0; 3];
         reader.read_exact(&mut buff)?;
@@ -38,6 +40,7 @@ impl FromToBytes for XyzRecord {
             classification,
             number_of_returns,
             return_number,
+            _padding: 0,
         })
     }
 
@@ -198,6 +201,7 @@ mod test {
             classification: 4,
             number_of_returns: 5,
             return_number: 6,
+            _padding: 0,
         };
 
         let mut buff = Vec::new();
@@ -219,6 +223,7 @@ mod test {
             classification: 4,
             number_of_returns: 5,
             return_number: 6,
+            _padding: 0,
         };
 
         writer.write_record(&record).unwrap();

--- a/src/process.rs
+++ b/src/process.rs
@@ -120,7 +120,7 @@ pub fn process_tile(
             let mut parts = line.split(' ');
             let x = parts.next().unwrap().parse::<f64>().unwrap();
             let y = parts.next().unwrap().parse::<f64>().unwrap();
-            let z = parts.next().unwrap().parse::<f64>().unwrap();
+            let z = parts.next().unwrap().parse::<f32>().unwrap();
 
             let classification = parts.next().unwrap().parse::<u8>().unwrap();
             let number_of_returns = parts.next().unwrap().parse::<u8>().unwrap();
@@ -134,6 +134,7 @@ pub fn process_tile(
                     classification,
                     number_of_returns,
                     return_number,
+                    ..Default::default()
                 })
                 .expect("Could not write record");
         })
@@ -170,10 +171,11 @@ pub fn process_tile(
                 writer.write_record(&crate::io::xyz::XyzRecord {
                     x: pt.x * xfactor,
                     y: pt.y * yfactor,
-                    z: pt.z * zfactor + zoff,
+                    z: (pt.z * zfactor + zoff) as f32,
                     classification: u8::from(pt.classification),
                     number_of_returns: pt.number_of_returns,
                     return_number: pt.return_number,
+                    ..Default::default()
                 })?;
             }
         }
@@ -438,10 +440,11 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                             .write_record(&crate::io::xyz::XyzRecord {
                                 x: pt.x,
                                 y: pt.y,
-                                z: pt.z + zoff,
+                                z: (pt.z + zoff) as f32,
                                 classification: u8::from(pt.classification),
                                 number_of_returns: pt.number_of_returns,
                                 return_number: pt.return_number,
+                                ..Default::default()
                             })
                             .expect("Could not write record");
                     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -127,6 +127,7 @@ pub fn process_tile(
             let number_of_returns = parts.next().unwrap().parse::<u8>().unwrap();
             let return_number = parts.next().unwrap().parse::<u8>().unwrap();
 
+            // TODO: write muliple records at once?
             writer
                 .write_records(&[crate::io::xyz::XyzRecord {
                     x,
@@ -447,6 +448,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
             {
                 let mut reader = Reader::new(fs.open(laz_p).expect("Could not open file"))
                     .expect("Could not create reader");
+                // TODO: read &write muliple records at once here too?
                 for ptu in reader.points() {
                     let pt = ptu.unwrap();
                     if pt.x > minx2

--- a/src/process.rs
+++ b/src/process.rs
@@ -24,6 +24,10 @@ use crate::util::Timing;
 use crate::util::read_lines_no_alloc;
 use crate::vegetation;
 
+// compute the number of elements we can buffer for 50MB of memory usage during LAZ -> XyzRecord conversion
+const LAZ_BUFFER_SIZE: usize =
+    50 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
+
 pub fn process_zip(
     fs: &impl FileSystem,
     config: &Config,
@@ -127,7 +131,6 @@ pub fn process_tile(
             let number_of_returns = parts.next().unwrap().parse::<u8>().unwrap();
             let return_number = parts.next().unwrap().parse::<u8>().unwrap();
 
-            // TODO: write muliple records at once?
             writer
                 .write_records(&[crate::io::xyz::XyzRecord {
                     x,
@@ -167,14 +170,11 @@ pub fn process_tile(
         let mut writer =
             XyzInternalWriter::new(fs.create(&target_file).expect("Could not create writer"));
 
-        // compute the buffer size for 50MB RAM usage
-        const TEMPSIZE: usize =
-            50 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
-        let mut points = Vec::with_capacity(TEMPSIZE);
-        let mut records = Vec::with_capacity(TEMPSIZE);
+        let mut points = Vec::with_capacity(LAZ_BUFFER_SIZE);
+        let mut records = Vec::with_capacity(LAZ_BUFFER_SIZE);
         loop {
             points.clear();
-            let n = reader.read_points_into(TEMPSIZE as u64, &mut points)?;
+            let n = reader.read_points_into(LAZ_BUFFER_SIZE as u64, &mut points)?;
 
             if n == 0 {
                 break;
@@ -437,6 +437,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
         let mut writer =
             XyzInternalWriter::new(fs.create(&tmp_filename).expect("Could not create writer"));
 
+        // read points from all LAZ files that have an overlap with the main tile file
         for laz_p in &laz_files {
             let laz = laz_p.as_path().file_name().unwrap().to_str().unwrap();
             let mut file = fs.open(format!("{lazfolder}/{laz}")).unwrap();
@@ -448,17 +449,29 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
             {
                 let mut reader = Reader::new(fs.open(laz_p).expect("Could not open file"))
                     .expect("Could not create reader");
-                // TODO: read &write muliple records at once here too?
-                for ptu in reader.points() {
-                    let pt = ptu.unwrap();
-                    if pt.x > minx2
-                        && pt.x < maxx2
-                        && pt.y > miny2
-                        && pt.y < maxy2
-                        && (thinfactor == 1.0 || rng.sample(randdist))
-                    {
-                        writer
-                            .write_records(&[crate::io::xyz::XyzRecord {
+
+                let mut points = Vec::with_capacity(LAZ_BUFFER_SIZE);
+                let mut records = Vec::with_capacity(LAZ_BUFFER_SIZE);
+                loop {
+                    points.clear();
+                    let n = reader
+                        .read_points_into(LAZ_BUFFER_SIZE as u64, &mut points)
+                        .expect("could not read LAZ points");
+
+                    if n == 0 {
+                        break;
+                    }
+
+                    // convert all read points to records
+                    records.clear();
+                    for pt in &points {
+                        if pt.x > minx2
+                            && pt.x < maxx2
+                            && pt.y > miny2
+                            && pt.y < maxy2
+                            && (thinfactor == 1.0 || rng.sample(randdist))
+                        {
+                            records.push(crate::io::xyz::XyzRecord {
                                 x: pt.x,
                                 y: pt.y,
                                 z: (pt.z + zoff) as f32,
@@ -466,9 +479,14 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                                 number_of_returns: pt.number_of_returns,
                                 return_number: pt.return_number,
                                 ..Default::default()
-                            }])
-                            .expect("Could not write record");
+                            });
+                        }
                     }
+
+                    // write all at once
+                    writer
+                        .write_records(&records)
+                        .expect("Could not write records");
                 }
             }
         }

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -77,8 +77,8 @@ pub fn makevege(
 
     let mut i = 0;
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next_chunk()? {
-        for r in r {
+    while let Some(chunk) = reader.next_chunk()? {
+        for r in chunk {
             if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
                 let x: f64 = r.x;
                 let y: f64 = r.y;
@@ -141,8 +141,8 @@ pub fn makevege(
 
     let mut i = 0;
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next_chunk()? {
-        for r in r {
+    while let Some(chunk) = reader.next_chunk()? {
+        for r in chunk {
             if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
                 let x: f64 = r.x;
                 let y: f64 = r.y;
@@ -477,8 +477,8 @@ pub fn makevege(
     let water = config.water;
     if buildings > 0 || water > 0 {
         let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-        while let Some(r) = reader.next_chunk()? {
-            for r in r {
+        while let Some(chunk) = reader.next_chunk()? {
+            for r in chunk {
                 let (x, y) = (r.x, r.y);
                 let c: u8 = r.classification;
 

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -77,45 +77,47 @@ pub fn makevege(
 
     let mut i = 0;
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next()? {
-        if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
-            let x: f64 = r.x;
-            let y: f64 = r.y;
-            let h: f64 = r.z as f64;
-            let r3 = r.classification;
-            let r4 = r.number_of_returns;
-            let r5 = r.return_number;
+    while let Some(r) = reader.next_chunk()? {
+        for r in r {
+            if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
+                let x: f64 = r.x;
+                let y: f64 = r.y;
+                let h: f64 = r.z as f64;
+                let r3 = r.classification;
+                let r4 = r.number_of_returns;
+                let r5 = r.return_number;
 
-            if xmax < x {
-                xmax = x;
-            }
-            if ymax < y {
-                ymax = y;
-            }
-            if x > xmin && y > ymin {
-                let xx = ((x - xmin) / block) as usize;
-                let yy = ((y - ymin) / block) as usize;
-                let t = &mut top[(xx, yy)];
-                if h > *t {
-                    *t = h;
+                if xmax < x {
+                    xmax = x;
                 }
-                let xx = ((x - xmin) / 3.0) as usize;
-                let yy = ((y - ymin) / 3.0) as usize;
+                if ymax < y {
+                    ymax = y;
+                }
+                if x > xmin && y > ymin {
+                    let xx = ((x - xmin) / block) as usize;
+                    let yy = ((y - ymin) / block) as usize;
+                    let t = &mut top[(xx, yy)];
+                    if h > *t {
+                        *t = h;
+                    }
+                    let xx = ((x - xmin) / 3.0) as usize;
+                    let yy = ((y - ymin) / 3.0) as usize;
 
-                if r3 == 2
-                    || h < yellowheight
-                        + xyz[(((x - xmin) / size) as usize, ((y - ymin) / size) as usize)]
-                {
-                    yhit[(xx, yy)] += 1;
-                } else if r4 == 1 && r5 == 1 {
-                    noyhit[(xx, yy)] += yellowfirstlast;
-                } else {
-                    noyhit[(xx, yy)] += 1;
+                    if r3 == 2
+                        || h < yellowheight
+                            + xyz[(((x - xmin) / size) as usize, ((y - ymin) / size) as usize)]
+                    {
+                        yhit[(xx, yy)] += 1;
+                    } else if r4 == 1 && r5 == 1 {
+                        noyhit[(xx, yy)] += yellowfirstlast;
+                    } else {
+                        noyhit[(xx, yy)] += 1;
+                    }
                 }
             }
+
+            i += 1;
         }
-
-        i += 1;
     }
     // rebind the variables to be non-mut for the rest of the function
     let (top, yhit, noyhit) = (top, yhit, noyhit);
@@ -139,91 +141,93 @@ pub fn makevege(
 
     let mut i = 0;
     let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-    while let Some(r) = reader.next()? {
-        if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
-            let x: f64 = r.x;
-            let y: f64 = r.y;
-            let h: f64 = r.z as f64 - zoffset;
-            let r3 = r.classification;
-            let r4 = r.number_of_returns;
-            let r5 = r.return_number;
+    while let Some(r) = reader.next_chunk()? {
+        for r in r {
+            if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
+                let x: f64 = r.x;
+                let y: f64 = r.y;
+                let h: f64 = r.z as f64 - zoffset;
+                let r3 = r.classification;
+                let r4 = r.number_of_returns;
+                let r5 = r.return_number;
 
-            if x > xmin && y > ymin {
-                if r5 == 1 {
+                if x > xmin && y > ymin {
+                    if r5 == 1 {
+                        let xx = ((x - xmin) / block + 0.5) as usize;
+                        let yy = ((y - ymin) / block + 0.5) as usize;
+                        firsthit[(xx, yy)] += 1;
+                    }
+
+                    let xx = ((x - xmin) / size) as usize;
+                    let yy = ((y - ymin) / size) as usize;
+                    let a = xyz[(xx, yy)];
+                    let b = xyz[(xx + 1, yy)];
+                    let c = xyz[(xx, yy + 1)];
+                    let d = xyz[(xx + 1, yy + 1)];
+
+                    let distx = (x - xmin) / size - xx as f64;
+                    let disty = (y - ymin) / size - yy as f64;
+
+                    let ab = a * (1.0 - distx) + b * distx;
+                    let cd = c * (1.0 - distx) + d * distx;
+                    let thelele = ab * (1.0 - disty) + cd * disty;
+                    let xx = ((x - xmin) / block / (step as f64) + 0.5) as usize;
+                    let yy = ((y - ymin) / block / (step as f64) + 0.5) as usize;
+                    let hh = h - thelele;
+                    let ug_entry = &mut ug[(xx, yy)];
+                    if hh <= 1.2 {
+                        if r3 == 2 {
+                            ug_entry.ugg += 1.0;
+                        } else if hh > 0.25 {
+                            ug_entry.ug += 1;
+                        } else {
+                            ug_entry.ugg += 1.0;
+                        }
+                    } else {
+                        ug_entry.ugg += 0.05;
+                    }
+
                     let xx = ((x - xmin) / block + 0.5) as usize;
                     let yy = ((y - ymin) / block + 0.5) as usize;
-                    firsthit[(xx, yy)] += 1;
-                }
-
-                let xx = ((x - xmin) / size) as usize;
-                let yy = ((y - ymin) / size) as usize;
-                let a = xyz[(xx, yy)];
-                let b = xyz[(xx + 1, yy)];
-                let c = xyz[(xx, yy + 1)];
-                let d = xyz[(xx + 1, yy + 1)];
-
-                let distx = (x - xmin) / size - xx as f64;
-                let disty = (y - ymin) / size - yy as f64;
-
-                let ab = a * (1.0 - distx) + b * distx;
-                let cd = c * (1.0 - distx) + d * distx;
-                let thelele = ab * (1.0 - disty) + cd * disty;
-                let xx = ((x - xmin) / block / (step as f64) + 0.5) as usize;
-                let yy = ((y - ymin) / block / (step as f64) + 0.5) as usize;
-                let hh = h - thelele;
-                let ug_entry = &mut ug[(xx, yy)];
-                if hh <= 1.2 {
-                    if r3 == 2 {
-                        ug_entry.ugg += 1.0;
-                    } else if hh > 0.25 {
-                        ug_entry.ug += 1;
-                    } else {
-                        ug_entry.ugg += 1.0;
-                    }
-                } else {
-                    ug_entry.ugg += 0.05;
-                }
-
-                let xx = ((x - xmin) / block + 0.5) as usize;
-                let yy = ((y - ymin) / block + 0.5) as usize;
-                let yyy = ((y - ymin) / block) as usize; // necessary due to bug in perl version
-                if r3 == 2 || greenground >= hh {
-                    if r4 == 1 && r5 == 1 {
-                        ghit[(xx, yyy)] += firstandlastreturnasground;
-                    } else {
-                        ghit[(xx, yyy)] += 1;
-                    }
-                } else {
-                    let mut last = 1.0;
-                    if r4 == r5 {
-                        last = lastfactor;
-                        if hh < 5.0 {
-                            last = firstandlastfactor;
+                    let yyy = ((y - ymin) / block) as usize; // necessary due to bug in perl version
+                    if r3 == 2 || greenground >= hh {
+                        if r4 == 1 && r5 == 1 {
+                            ghit[(xx, yyy)] += firstandlastreturnasground;
+                        } else {
+                            ghit[(xx, yyy)] += 1;
                         }
-                    }
-
-                    let top_val = top[(xx, yy)];
-                    for &Zone {
-                        low,
-                        high,
-                        roof,
-                        factor,
-                    } in config.zones.iter()
-                    {
-                        if hh >= low && hh < high && top_val - thelele < roof {
-                            greenhit[(xx, yy)] += (factor * last) as f32;
-                            break;
+                    } else {
+                        let mut last = 1.0;
+                        if r4 == r5 {
+                            last = lastfactor;
+                            if hh < 5.0 {
+                                last = firstandlastfactor;
+                            }
                         }
-                    }
 
-                    if greenhigh < hh {
-                        highit[(xx, yy)] += 1;
+                        let top_val = top[(xx, yy)];
+                        for &Zone {
+                            low,
+                            high,
+                            roof,
+                            factor,
+                        } in config.zones.iter()
+                        {
+                            if hh >= low && hh < high && top_val - thelele < roof {
+                                greenhit[(xx, yy)] += (factor * last) as f32;
+                                break;
+                            }
+                        }
+
+                        if greenhigh < hh {
+                            highit[(xx, yy)] += 1;
+                        }
                     }
                 }
             }
-        }
 
-        i += 1;
+            i += 1;
+        }
     }
     // rebind the variables to be non-mut for the rest of the function
     let (firsthit, ug, ghit, greenhit, highit) = (firsthit, ug, ghit, greenhit, highit);
@@ -473,23 +477,25 @@ pub fn makevege(
     let water = config.water;
     if buildings > 0 || water > 0 {
         let mut reader = XyzInternalReader::new(fs.open(&xyz_file_in)?)?;
-        while let Some(r) = reader.next()? {
-            let (x, y) = (r.x, r.y);
-            let c: u8 = r.classification;
+        while let Some(r) = reader.next_chunk()? {
+            for r in r {
+                let (x, y) = (r.x, r.y);
+                let c: u8 = r.classification;
 
-            if c == buildings {
-                draw_filled_rect_mut(
-                    &mut imgwater,
-                    Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
-                    black,
-                );
-            }
-            if c == water {
-                draw_filled_rect_mut(
-                    &mut imgwater,
-                    Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
-                    blue,
-                );
+                if c == buildings {
+                    draw_filled_rect_mut(
+                        &mut imgwater,
+                        Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
+                        black,
+                    );
+                }
+                if c == water {
+                    draw_filled_rect_mut(
+                        &mut imgwater,
+                        Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
+                        blue,
+                    );
+                }
             }
         }
     }

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -81,7 +81,7 @@ pub fn makevege(
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
             let y: f64 = r.y;
-            let h: f64 = r.z;
+            let h: f64 = r.z as f64;
             let r3 = r.classification;
             let r4 = r.number_of_returns;
             let r5 = r.return_number;
@@ -143,7 +143,7 @@ pub fn makevege(
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
             let y: f64 = r.y;
-            let h: f64 = r.z - zoffset;
+            let h: f64 = r.z as f64 - zoffset;
             let r3 = r.classification;
             let r4 = r.number_of_returns;
             let r5 = r.return_number;


### PR DESCRIPTION
So far we have been storing the `XyzRecord`s in the temporary `.xyz.bin` file with `x`, `y`, and `z` (height) as `f64`. With the other 3 `u8` flags stored, this means that the `XyzRecord` struct needs to contain 5 padding bytes and takes up a full 32 bytes in memory. This also means that we opted for a data format where each field is serialized separately to "pack" the data as much as possible on disk since always reading and writing those 5 bytes * 30 million records means there is a lot of "dead" storage used (like 200MB in this example). 

Since the `z` coordinate is treated as "height" in meters, we can be pretty confident that it only contains values in the range 0-5000 meters, in which a `f32` contains sufficient significant digits to represent the height with centimeter accuracy. According to the [Wikipedia page on `f32`](https://en.wikipedia.org/wiki/Single-precision_floating-point_format), for integer values in the range `2^12 = 4096` to `2^13 = 8192`, the fixed interval between the representable decimals is `2^(12−23)=2^(-11) = 0.000488...` which in my opinion is enough resolution for a height value.

So therefore this PR changes the `z` field to be a `f32`, which not only reduces the size on data on disk (23 vs 27 bytes / point), it also means that it contains just a single padding byte. Hence we can utilize the [`bytemuck`] crate to _very efficiently_ (ie. basically for free) write _and read_ single `XyzRecord` and slices `&[XyzRecord]` to/from `&[u8]`. This _hugely_ speeds up both read and write times and since a lot of time is spent reading these bytes we get a nice speedup.

Since we can now read and write slices of these `XyzRecord`, I also figured it makes sense to read and write them as chunks instead of in single items. For writing, I also changed so that we read multiple of the (potentially compressed) LAZ points at once and then write them in chunks, with a buffer size that uses about `50MB` of memory (which I figured should be fine for most users since our top RAM usage is around 1GB during rendering). Reading reads into a single buffer of `1024` elements at once, and returns a _borrowed slice_ instead of a _copy_ as it did before. This also means that the processing steps now need to iterate over each point in these "chunks" which gives the compiler an easier time to actually vectorize these functions more aggressively (whenever possibly). Note that by default, the compiler is quite conservative (basically only using `SSE` and not emitting wider `SSE2` - `SSE4`, `AVX`, `AVX2` and `AVX512` instructions) since it produces highly portable executables. We could consider releasing separate artifacts with these features enabled, or decide a "lower bound" of what to support (eg. require `SSE4` or `AVX` on `x86_64`). It can also be done with something like the [`multiversion`](https://crates.io/crates/multiversion) crate.

All-in-all we see around 4s (~10%) of speedup on the regression tests :fire:   

The regression tests fail because some smaller changes in the output like slightly shifted contours in _very few_ places. Comparison says that `99.9` % of pixels are the same. Worth noting is that this PR does not change the generation logic, which still uses `f64` for the height during processing (only loads a `f32` and converts it into `f64` before continuing as usual). This could be done in a separate PR since it might cause larger changes to the output.