### PR TITLE
feat: add configuration option to decompress LAZ files in parallell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "las"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3363b1d6ce3d4999d2ec42eced71e4b90a9ef7bacf9a9b7b873d501f3d13502"
+checksum = "ebfd84a9c6b1e59d130f14b18d78ccdefc535d1e760ce2179cda996f8e863578"
 dependencies = [
  "byteorder",
  "chrono",
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "laz"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9be1582ff02cb56b08a4d273cc5f77eacd89d33a0c682ede9d0912e1c17773"
+checksum = "b03d52bffba2ed388c11c86ade5a4118d5b852fc244d2bc803bf21f19b12fb44"
 dependencies = [
  "byteorder",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ checksum = "b03d52bffba2ed388c11c86ade5a4118d5b852fc244d2bc803bf21f19b12fb44"
 dependencies = [
  "byteorder",
  "num-traits",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ imageproc = { version = "0.25.0", default-features = false, features = [
 	"rayon",
 ] }
 
-las = { version = "0.9", features = ["laz"] }
+las = { version = "0.9", features = ["laz", "laz-parallel"] }
 rand = "0.9"
 rust-ini = "0.21"
 rustc-hash = "2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,9 @@ pub struct Config {
     pub batch: bool,
     pub processes: u64,
 
+    /// If true, use parallel decompression for LAZ files.
+    pub laz_parallell: bool,
+
     pub experimental_use_in_memory_fs: bool,
 
     /// Whether to output the result as DXF.
@@ -155,6 +158,7 @@ impl Config {
                 .unwrap_or(default)
         }
 
+        let laz_parallell: bool = gs.get("parallell_laz_decompression").unwrap_or("0") == "1";
         let output_dxf: bool = gs.get("output_dxf").unwrap_or("0") == "1";
 
         let pnorthlinesangle: f64 = parse_typed(gs, "northlinesangle", 0.0);
@@ -348,6 +352,7 @@ impl Config {
             batch,
             processes,
             output_dxf,
+            laz_parallell,
             experimental_use_in_memory_fs,
             vegeonly,
             cliffsonly,

--- a/src/process.rs
+++ b/src/process.rs
@@ -163,8 +163,14 @@ pub fn process_tile(
         let mut rng = rand::rng();
         let randdist = rand::distr::Bernoulli::new(thinfactor).unwrap();
 
-        let mut reader = Reader::new(fs.open(input_file).expect("Could not open file"))
-            .expect("Could not create reader");
+        let options = las::ReaderOptions::default().with_laz_parallelism(if config.laz_parallell {
+            las::LazParallelism::Yes
+        } else {
+            las::LazParallelism::No
+        });
+        let mut reader =
+            Reader::with_options(fs.open(input_file).expect("Could not open file"), options)
+                .expect("Could not create reader");
 
         debug!("Writing records to {:?}", &target_file);
         let mut writer =
@@ -404,6 +410,12 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
         }
     }
 
+    let options = las::ReaderOptions::default().with_laz_parallelism(if conf.laz_parallell {
+        las::LazParallelism::Yes
+    } else {
+        las::LazParallelism::No
+    });
+
     for laz_path in &laz_files {
         let laz = laz_path.file_name().unwrap().to_str().unwrap();
         let outfile = format!("{batchoutfolder}/{laz}.png");
@@ -447,8 +459,9 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                 && header.max_y > miny2
                 && header.min_y < maxy2
             {
-                let mut reader = Reader::new(fs.open(laz_p).expect("Could not open file"))
-                    .expect("Could not create reader");
+                let mut reader =
+                    Reader::with_options(fs.open(laz_p).expect("Could not open file"), options)
+                        .expect("Could not create reader");
 
                 let mut points = Vec::with_capacity(LAZ_BUFFER_SIZE);
                 let mut records = Vec::with_capacity(LAZ_BUFFER_SIZE);


### PR DESCRIPTION
After the `las` crate recently added support for selecting whether to use the multi or single threaded reader at runtime (instead of at compile time using the `laz-parallell` feature) in https://github.com/gadomski/las-rs/pull/117, we can now allow the user to enable it with a new configuration flag `parallell_laz_decompression`. This shortens the decompression step (which for me makes up around one third of the total processing time) substantially :fire: On my old laptop with four cores it cuts time from 20 to 10 seconds.

Since it uses `rayon` under the hood, I suspect there is a thread pool which by default creates as many threads as there are cores. And as such it should not interfere with the "processes" flag and create too many threads. Perhaps we could consider to use rayon internally as well as it would then run on the same thread pool, and we could limit the parallellism there directly, but that might be a future PR.

As for the defaults, for now it is the following:

- the flag is enabled in the default `ini` file.
- If the flag is missing (eg. since you are using an existing `ini` file), it defaults to off. 

This means that it is "opt-in" for existing configurations, but the default for newly generated ones. Does that make sense or should we just blindly enable it for all by default?