### PR TITLE
fix: drop file instead of flushing

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -131,7 +131,7 @@ fn merge_png(
         ymax
     )
     .expect("Could not write to file");
-    tfw_file.flush().expect("Cannot flush");
+    drop(tfw_file);
     fs.copy(
         Path::new(&format!("{outfilename}.pgw")),
         Path::new(&format!("{outfilename}.jgw")),

--- a/src/process.rs
+++ b/src/process.rs
@@ -585,7 +585,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
             )
             .expect("Unable to write to file");
 
-            pgw_file_out.flush().unwrap();
+            drop(pgw_file_out);
             fs.copy(
                 Path::new(&format!("pullautus{thread}.pgw")),
                 Path::new(&format!("pullautus_depr{thread}.pgw")),
@@ -718,7 +718,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                     maxy - tfw0 / 2.0
                 )
                 .expect("Unable to write to file");
-                pgw_file_out.flush().unwrap();
+                drop(pgw_file_out);
 
                 let mut orig_img_reader = image::ImageReader::new(
                     fs.open(format!("temp{thread}/undergrowth.png"))
@@ -780,7 +780,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
                 )
                 .expect("Unable to write to file");
 
-                pgw_file_out.flush().unwrap();
+                drop(pgw_file_out);
 
                 if vege_bitmode {
                     let mut orig_img_reader = image::ImageReader::new(


### PR DESCRIPTION
For the in-memory FS, the data is actually atomically written into the file-tree only once the file is dropped. This caused issues in some places where the `pgw` files were written to and then only `flush`ed before being copied to other places.
This PR fixes that by (correctly) closing the file handle (eg. dropping it) once the file is completely written.

Closes #223  