### PR TITLE
chore(deps): bump `rand` to `v0.9.4` and `v0.10.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
  "itertools",
  "nalgebra",
  "num",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
 ]
@@ -1346,7 +1346,7 @@ dependencies = [
  "imageproc",
  "las",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rust-ini",
  "rustc-hash",
  "serde",
@@ -1390,9 +1390,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -1441,7 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1471,7 +1471,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "simd_helpers",
  "thiserror",


### PR DESCRIPTION
Solves issues reported by dependabot:

https://github.com/karttapullautin/karttapullautin/security/dependabot/4
https://github.com/karttapullautin/karttapullautin/security/dependabot/6