### PR TITLE
feat: generate and write indexed PNGs directly during vegetation generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "imageproc",
  "las",
  "log",
+ "png",
  "rand 0.10.1",
  "rust-ini",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ image = { version = "0.25", default-features = false, features = [
 	"jpeg",
 ] }
 
+png = "0.18"
+
 imageproc = { version = "0.26", default-features = false, features = [
 	"rayon",
 ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod geometry;
 pub mod io;
 pub mod knolls;
 pub mod merge;
+pub mod palette;
 pub mod process;
 pub mod render;
 pub mod util;

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -4,6 +4,7 @@ use image::{Luma, Rgba};
 use crate::config::Config;
 
 /// Our own wrapper around and image buffer that automatically handles drawing with a palette.
+#[derive(Clone)]
 pub struct OurImage {
     /// the inner paletted image
     image: image::ImageBuffer<PaletteColor, Vec<u8>>,
@@ -44,6 +45,13 @@ impl OurImage {
         Self { image }
     }
 
+    pub fn width(&self) -> u32 {
+        self.image.width()
+    }
+    pub fn height(&self) -> u32 {
+        self.image.height()
+    }
+
     pub fn median_filter(&self, x_radius: u32, y_radius: u32) -> Self {
         let filtered_image = imageproc::filter::median_filter(&self.image, x_radius, y_radius);
         Self {
@@ -53,6 +61,10 @@ impl OurImage {
 
     pub fn draw_filled_rect(&mut self, rect: imageproc::rect::Rect, color: PaletteColor) {
         imageproc::drawing::draw_filled_rect_mut(&mut self.image, rect, color);
+    }
+
+    pub fn pixels(&self) -> impl Iterator<Item = &PaletteColor> {
+        self.image.pixels()
     }
 
     /// Convert this image to an RGBA image using the given palette.
@@ -150,8 +162,14 @@ impl Palette {
                     (greentone - greentone / (num_greenshades - 1) as f64 * i as f64) as u8,
                     255,
                 ]);
+                // index starts at 2 for the first green tone apparently
+                let bit_value = i as u8 + 2;
+                palette[PaletteColorEnum::GreenShadeBit(i as u8)] =
+                    Rgba([bit_value, bit_value, bit_value, 255]);
             }
         }
+
+        // palette[PaletteColorEnum::GreenShadeBitNotFound] = Rgba([0, 0, 0, 255]);
 
         palette[PaletteColorEnum::BackgroundWhite] = Rgba([255, 255, 255, 255]);
         palette[PaletteColorEnum::Black] = Rgba([0, 0, 0, 255]);
@@ -175,6 +193,10 @@ pub enum PaletteColorEnum {
     /// A shade of green used for vegetation. Number of shades are configured by the config. Maximum
     /// 16 shades, so we have to reserve 16 colors for this.
     GreenShade(u8),
+    /// Used to output bit images of the green shades, where the value is directly translated into
+    /// [value, value, value, 255] in the palette, where value is between 0 and 15.
+    GreenShadeBit(u8),
+    // GreenShadeBitNotFound,
 }
 
 impl PaletteColorEnum {
@@ -190,6 +212,10 @@ impl PaletteColorEnum {
             Self::GreenShade(shade) => {
                 assert!(*shade < 16, "Green shade must be between 0 and 15");
                 PaletteColor(Luma([16 + *shade]))
+            }
+            Self::GreenShadeBit(shade) => {
+                assert!(*shade < 16, "Green shade bit must be between 0 and 15");
+                PaletteColor(Luma([32 + *shade]))
             }
         }
     }

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,17 +1,15 @@
-use anyhow::Context;
 use image::{Luma, Rgba};
 
 use crate::config::Config;
 
 /// Our own wrapper around and image buffer that automatically handles drawing with a palette.
 #[derive(Clone)]
-pub struct OurImage {
+pub struct PalettedImage {
     /// the inner paletted image
     image: image::ImageBuffer<PaletteColor, Vec<u8>>,
-    // TODO: reference the palette here? Arc?
 }
 
-impl imageproc::drawing::Canvas for OurImage {
+impl imageproc::drawing::Canvas for PalettedImage {
     type Pixel = PaletteColor;
 
     fn dimensions(&self) -> (u32, u32) {
@@ -34,7 +32,7 @@ impl imageproc::drawing::Canvas for OurImage {
     }
 }
 
-impl OurImage {
+impl PalettedImage {
     pub fn new(width: u32, height: u32, fill: PaletteColor) -> Self {
         let mut image = image::ImageBuffer::new(width, height);
 
@@ -65,11 +63,6 @@ impl OurImage {
 
     pub fn pixels(&self) -> impl Iterator<Item = &PaletteColor> {
         self.image.pixels()
-    }
-
-    /// Convert this image to an RGBA image using the given palette.
-    pub fn to_rgba(&self, palette: &Palette) -> image::RgbaImage {
-        crate::util::expand_palette_index(&self.image, &palette.colors)
     }
 
     /// Overlay other ontop of this image, blending the colors (taking top color if not transparent)
@@ -103,15 +96,6 @@ impl OurImage {
         w.write_image_data(self.image.as_raw())
             .expect("Failed to write PNG data");
         Ok(())
-    }
-
-    pub fn write_to_rgb<W>(&self, writer: &mut W, palette: &Palette) -> anyhow::Result<()>
-    where
-        W: std::io::Write + std::io::Seek,
-    {
-        self.to_rgba(palette)
-            .write_to(writer, image::ImageFormat::Png)
-            .context("writing image")
     }
 }
 
@@ -162,14 +146,8 @@ impl Palette {
                     (greentone - greentone / (num_greenshades - 1) as f64 * i as f64) as u8,
                     255,
                 ]);
-                // index starts at 2 for the first green tone apparently
-                let bit_value = i as u8 + 2;
-                palette[PaletteColorEnum::GreenShadeBit(i as u8)] =
-                    Rgba([bit_value, bit_value, bit_value, 255]);
             }
         }
-
-        // palette[PaletteColorEnum::GreenShadeBitNotFound] = Rgba([0, 0, 0, 255]);
 
         palette[PaletteColorEnum::BackgroundWhite] = Rgba([255, 255, 255, 255]);
         palette[PaletteColorEnum::Black] = Rgba([0, 0, 0, 255]);
@@ -193,10 +171,6 @@ pub enum PaletteColorEnum {
     /// A shade of green used for vegetation. Number of shades are configured by the config. Maximum
     /// 16 shades, so we have to reserve 16 colors for this.
     GreenShade(u8),
-    /// Used to output bit images of the green shades, where the value is directly translated into
-    /// [value, value, value, 255] in the palette, where value is between 0 and 15.
-    GreenShadeBit(u8),
-    // GreenShadeBitNotFound,
 }
 
 impl PaletteColorEnum {
@@ -213,10 +187,6 @@ impl PaletteColorEnum {
                 assert!(*shade < 16, "Green shade must be between 0 and 15");
                 PaletteColor(Luma([16 + *shade]))
             }
-            Self::GreenShadeBit(shade) => {
-                assert!(*shade < 16, "Green shade bit must be between 0 and 15");
-                PaletteColor(Luma([32 + *shade]))
-            }
         }
     }
 }
@@ -224,7 +194,7 @@ impl PaletteColorEnum {
 /// The index of a color in the palette. The palette contains up to 256 colors, so this is a single byte.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct PaletteColor(pub image::Luma<u8>);
+pub struct PaletteColor(image::Luma<u8>);
 
 #[allow(unused_variables)]
 impl image::Pixel for PaletteColor {

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -130,7 +130,7 @@ impl Palette {
 
         // initialize the palette with the colors from the config, and any hard-coded colors
 
-        palette[PaletteColorEnum::Transparent] = Rgba([0, 0, 0, 0]);
+        palette[PaletteColorEnum::Transparent] = Rgba([255, 255, 255, 0]);
 
         palette[PaletteColorEnum::Yellow2] = Rgba([255, 219, 166, 255]);
 

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -21,8 +21,7 @@ impl imageproc::drawing::Canvas for PalettedImage {
     }
 
     fn draw_pixel(&mut self, x: u32, y: u32, color: Self::Pixel) {
-        // custom logic to honor transparency (TODO: not needed when we never draw with any transparent color...)
-        // Also ignore any background white
+        // custom logic to honor transparency Also ignore any background white
         if color == PaletteColorEnum::Transparent.to_color()
             || color == PaletteColorEnum::BackgroundWhite.to_color()
         {

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,0 +1,332 @@
+use anyhow::Context;
+use image::{Luma, Rgba};
+
+use crate::config::Config;
+
+/// Our own wrapper around and image buffer that automatically handles drawing with a palette.
+pub struct OurImage {
+    /// the inner paletted image
+    image: image::ImageBuffer<PaletteColor, Vec<u8>>,
+    // TODO: reference the palette here? Arc?
+}
+
+impl imageproc::drawing::Canvas for OurImage {
+    type Pixel = PaletteColor;
+
+    fn dimensions(&self) -> (u32, u32) {
+        self.image.dimensions()
+    }
+
+    fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
+        *self.image.get_pixel(x, y)
+    }
+
+    fn draw_pixel(&mut self, x: u32, y: u32, color: Self::Pixel) {
+        // custom logic to honor transparency (TODO: not needed when we never draw with any transparent color...)
+        // Also ignore any background white
+        if color == PaletteColorEnum::Transparent.to_color()
+            || color == PaletteColorEnum::BackgroundWhite.to_color()
+        {
+            return;
+        }
+        self.image.put_pixel(x, y, color);
+    }
+}
+
+impl OurImage {
+    pub fn new(width: u32, height: u32, fill: PaletteColor) -> Self {
+        let mut image = image::ImageBuffer::new(width, height);
+
+        for p in image.pixels_mut() {
+            *p = fill;
+        }
+
+        Self { image }
+    }
+
+    pub fn median_filter(&self, x_radius: u32, y_radius: u32) -> Self {
+        let filtered_image = imageproc::filter::median_filter(&self.image, x_radius, y_radius);
+        Self {
+            image: filtered_image,
+        }
+    }
+
+    pub fn draw_filled_rect(&mut self, rect: imageproc::rect::Rect, color: PaletteColor) {
+        imageproc::drawing::draw_filled_rect_mut(&mut self.image, rect, color);
+    }
+
+    /// Convert this image to an RGBA image using the given palette.
+    pub fn to_rgba(&self, palette: &Palette) -> image::RgbaImage {
+        crate::util::expand_palette_index(&self.image, &palette.colors)
+    }
+
+    /// Overlay other ontop of this image, blending the colors (taking top color if not transparent)
+    pub fn overlay(&mut self, top: &Self, x: i64, y: i64) {
+        image::imageops::overlay(&mut self.image, &top.image, x, y);
+    }
+
+    /// writes an indexed PNG to the specified writer
+    pub fn write_to<W>(&self, writer: &mut W, palette: &Palette) -> anyhow::Result<()>
+    where
+        W: std::io::Write + std::io::Seek,
+    {
+        let mut encoder = png::Encoder::new(writer, self.image.width(), self.image.height());
+        encoder.set_color(png::ColorType::Indexed);
+        encoder.set_depth(png::BitDepth::Eight);
+
+        // create and fill palette array from provided palette
+        let mut palette_bytes = [0; 256 * 3];
+        let mut transparency_bytes = [0; 256];
+
+        for (i, color) in palette.colors.iter().enumerate() {
+            palette_bytes[i * 3] = color[0];
+            palette_bytes[i * 3 + 1] = color[1];
+            palette_bytes[i * 3 + 2] = color[2];
+            transparency_bytes[i] = color[3];
+        }
+        encoder.set_palette(&palette_bytes);
+        encoder.set_trns(&transparency_bytes);
+
+        let mut w = encoder.write_header().expect("Failed to write PNG header");
+        w.write_image_data(self.image.as_raw())
+            .expect("Failed to write PNG data");
+        Ok(())
+    }
+
+    pub fn write_to_rgb<W>(&self, writer: &mut W, palette: &Palette) -> anyhow::Result<()>
+    where
+        W: std::io::Write + std::io::Seek,
+    {
+        self.to_rgba(palette)
+            .write_to(writer, image::ImageFormat::Png)
+            .context("writing image")
+    }
+}
+
+/// Contains the global color palette for rendering.
+pub struct Palette {
+    colors: [image::Rgba<u8>; 256],
+}
+
+impl std::ops::Index<PaletteColorEnum> for Palette {
+    type Output = image::Rgba<u8>;
+
+    fn index(&self, index: PaletteColorEnum) -> &Self::Output {
+        &self.colors[index.to_color().0[0] as usize]
+    }
+}
+
+impl std::ops::IndexMut<PaletteColorEnum> for Palette {
+    fn index_mut(&mut self, index: PaletteColorEnum) -> &mut Self::Output {
+        &mut self.colors[index.to_color().0[0] as usize]
+    }
+}
+
+impl Palette {
+    pub fn new(config: &Config) -> Self {
+        let colors = [image::Rgba([0, 0, 0, 0]); 256];
+
+        let mut palette = Self { colors };
+
+        // initialize the palette with the colors from the config, and any hard-coded colors
+
+        palette[PaletteColorEnum::Transparent] = Rgba([0, 0, 0, 0]);
+
+        palette[PaletteColorEnum::Yellow2] = Rgba([255, 219, 166, 255]);
+
+        {
+            let num_greenshades = config.greenshades.len();
+            let greentone = config.greentone;
+
+            assert!(
+                num_greenshades <= 16,
+                "Number of green shades must be between 0 and 16"
+            );
+
+            for i in 0..num_greenshades {
+                palette[PaletteColorEnum::GreenShade(i as u8)] = Rgba([
+                    (greentone - greentone / (num_greenshades - 1) as f64 * i as f64) as u8,
+                    (254.0 - (74.0 / (num_greenshades - 1) as f64) * i as f64) as u8,
+                    (greentone - greentone / (num_greenshades - 1) as f64 * i as f64) as u8,
+                    255,
+                ]);
+            }
+        }
+
+        palette[PaletteColorEnum::BackgroundWhite] = Rgba([255, 255, 255, 255]);
+        palette[PaletteColorEnum::Black] = Rgba([0, 0, 0, 255]);
+        palette[PaletteColorEnum::Blue] = Rgba([29, 190, 255, 255]);
+        palette[PaletteColorEnum::Undergrowth] = Rgba([64, 121, 0, 255]);
+
+        palette
+    }
+}
+
+#[repr(u8)]
+pub enum PaletteColorEnum {
+    /// Transparent background color.
+    Transparent,
+    BackgroundWhite,
+    Black,
+    /// Yellow used for open areas.
+    Yellow2,
+    Undergrowth,
+    Blue,
+    /// A shade of green used for vegetation. Number of shades are configured by the config. Maximum
+    /// 16 shades, so we have to reserve 16 colors for this.
+    GreenShade(u8),
+}
+
+impl PaletteColorEnum {
+    pub const fn to_color(&self) -> PaletteColor {
+        match self {
+            Self::Transparent => PaletteColor(Luma([0])),
+            Self::BackgroundWhite => PaletteColor(Luma([1])),
+            Self::Black => PaletteColor(Luma([2])),
+            Self::Yellow2 => PaletteColor(Luma([3])),
+            Self::Blue => PaletteColor(Luma([4])),
+            Self::Undergrowth => PaletteColor(Luma([5])),
+
+            Self::GreenShade(shade) => {
+                assert!(*shade < 16, "Green shade must be between 0 and 15");
+                PaletteColor(Luma([16 + *shade]))
+            }
+        }
+    }
+}
+
+/// The index of a color in the palette. The palette contains up to 256 colors, so this is a single byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PaletteColor(pub image::Luma<u8>);
+
+#[allow(unused_variables)]
+impl image::Pixel for PaletteColor {
+    type Subpixel = u8;
+
+    const CHANNEL_COUNT: u8 = 1;
+    const HAS_ALPHA: bool = false;
+
+    fn channels(&self) -> &[Self::Subpixel] {
+        self.0.channels()
+    }
+
+    fn channels_mut(&mut self) -> &mut [Self::Subpixel] {
+        self.0.channels_mut()
+    }
+
+    const COLOR_MODEL: &'static str = "Palette";
+
+    fn channels4(
+        &self,
+    ) -> (
+        Self::Subpixel,
+        Self::Subpixel,
+        Self::Subpixel,
+        Self::Subpixel,
+    ) {
+        #[allow(deprecated)]
+        self.0.channels4()
+    }
+
+    fn from_channels(
+        a: Self::Subpixel,
+        b: Self::Subpixel,
+        c: Self::Subpixel,
+        d: Self::Subpixel,
+    ) -> Self {
+        #[allow(deprecated)]
+        Self(Luma::<u8>::from_channels(a, b, c, d))
+    }
+
+    fn from_slice(slice: &[Self::Subpixel]) -> &Self {
+        assert_eq!(slice.len(), 1);
+        // SAFETY: We have asserted that the slice has the correct length, and we use
+        // repr(transparent) on an object that does exactly this internally, so it is safe
+        // reinterpret it as a reference to Self.
+        unsafe { &*(slice.as_ptr() as *const Self) }
+    }
+
+    fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self {
+        assert_eq!(slice.len(), 1);
+        // SAFETY: We have asserted that the slice has the correct length, and we use
+        // repr(transparent) on an object that does exactly this internally, so it is safe
+        // reinterpret it as a reference to Self.
+        unsafe { &mut *(slice.as_mut_ptr() as *mut Self) }
+    }
+
+    fn to_rgb(&self) -> image::Rgb<Self::Subpixel> {
+        self.0.to_rgb()
+    }
+
+    fn to_rgba(&self) -> image::Rgba<Self::Subpixel> {
+        self.0.to_rgba()
+    }
+
+    fn to_luma(&self) -> image::Luma<Self::Subpixel> {
+        self.0.to_luma()
+    }
+
+    fn to_luma_alpha(&self) -> image::LumaA<Self::Subpixel> {
+        self.0.to_luma_alpha()
+    }
+
+    fn map<F>(&self, f: F) -> Self
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        unimplemented!()
+    }
+
+    fn apply<F>(&mut self, f: F)
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        unimplemented!()
+    }
+
+    fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+        G: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        unimplemented!()
+    }
+
+    fn apply_with_alpha<F, G>(&mut self, f: F, g: G)
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+        G: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        unimplemented!()
+    }
+
+    fn map2<F>(&self, other: &Self, f: F) -> Self
+    where
+        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel,
+    {
+        unimplemented!()
+    }
+
+    fn apply2<F>(&mut self, other: &Self, f: F)
+    where
+        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel,
+    {
+        unimplemented!()
+    }
+
+    fn invert(&mut self) {
+        unimplemented!()
+    }
+
+    fn blend(&mut self, other: &Self) {
+        // if we are blending with a transparent color, we should not change the color at all
+        if *other == PaletteColorEnum::Transparent.to_color()
+            || *other == PaletteColorEnum::BackgroundWhite.to_color()
+        {
+            return;
+        }
+
+        *self = *other;
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::Context;
 use log::debug;
 
-use crate::{io::fs::FileSystem, palette::PaletteColor};
+use crate::io::fs::FileSystem;
 
 /// Iterates over the lines in a file and calls the callback with a &str reference to each line.
 /// This function does not allocate new strings for each line, as opposed to using
@@ -151,56 +151,4 @@ pub fn write_object<W: std::io::Write, O: serde::Serialize>(
     )
     .context("serializing to file")?;
     Ok(())
-}
-
-/// Expands a grayscale / indexed image using a palette into an image with the same dimensions.
-/// This allocates a new buffer to hold the expanded image.
-pub fn expand_palette<P: image::Pixel>(
-    img: &image::GrayImage,
-    palette: &[P],
-) -> image::ImageBuffer<P, Vec<P::Subpixel>> {
-    let mut expanded = image::ImageBuffer::new(img.width(), img.height());
-
-    for (idx, pixel) in img.pixels().zip(expanded.pixels_mut()) {
-        let idx = idx.0[0];
-        *pixel = palette[idx as usize];
-    }
-
-    expanded
-}
-
-pub fn expand_palette_index<P: image::Pixel>(
-    img: &image::ImageBuffer<PaletteColor, Vec<u8>>,
-    palette: &[P],
-) -> image::ImageBuffer<P, Vec<P::Subpixel>> {
-    let mut expanded = image::ImageBuffer::new(img.width(), img.height());
-
-    for (idx, pixel) in img.pixels().zip(expanded.pixels_mut()) {
-        let idx = idx.0[0];
-        *pixel = palette[idx as usize];
-    }
-
-    expanded
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_expand_palette() {
-        let img = image::GrayImage::from_raw(2, 2, vec![0, 1, 2, 3]).unwrap();
-        let palette = [
-            image::Rgb([255, 0, 0]),
-            image::Rgb([0, 255, 0]),
-            image::Rgb([0, 0, 255]),
-            image::Rgb([255, 255, 0]),
-        ];
-
-        let expanded = expand_palette(&img, &palette);
-        assert_eq!(expanded.get_pixel(0, 0), &image::Rgb([255, 0, 0]));
-        assert_eq!(expanded.get_pixel(1, 0), &image::Rgb([0, 255, 0]));
-        assert_eq!(expanded.get_pixel(0, 1), &image::Rgb([0, 0, 255]));
-        assert_eq!(expanded.get_pixel(1, 1), &image::Rgb([255, 255, 0]));
-    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::Context;
 use log::debug;
 
-use crate::io::fs::FileSystem;
+use crate::{io::fs::FileSystem, palette::PaletteColor};
 
 /// Iterates over the lines in a file and calls the callback with a &str reference to each line.
 /// This function does not allocate new strings for each line, as opposed to using
@@ -156,7 +156,21 @@ pub fn write_object<W: std::io::Write, O: serde::Serialize>(
 /// Expands a grayscale / indexed image using a palette into an image with the same dimensions.
 /// This allocates a new buffer to hold the expanded image.
 pub fn expand_palette<P: image::Pixel>(
-    img: image::GrayImage,
+    img: &image::GrayImage,
+    palette: &[P],
+) -> image::ImageBuffer<P, Vec<P::Subpixel>> {
+    let mut expanded = image::ImageBuffer::new(img.width(), img.height());
+
+    for (idx, pixel) in img.pixels().zip(expanded.pixels_mut()) {
+        let idx = idx.0[0];
+        *pixel = palette[idx as usize];
+    }
+
+    expanded
+}
+
+pub fn expand_palette_index<P: image::Pixel>(
+    img: &image::ImageBuffer<PaletteColor, Vec<u8>>,
     palette: &[P],
 ) -> image::ImageBuffer<P, Vec<P::Subpixel>> {
     let mut expanded = image::ImageBuffer::new(img.width(), img.height());
@@ -183,7 +197,7 @@ mod tests {
             image::Rgb([255, 255, 0]),
         ];
 
-        let expanded = expand_palette(img, &palette);
+        let expanded = expand_palette(&img, &palette);
         assert_eq!(expanded.get_pixel(0, 0), &image::Rgb([255, 0, 0]));
         assert_eq!(expanded.get_pixel(1, 0), &image::Rgb([0, 255, 0]));
         assert_eq!(expanded.get_pixel(0, 1), &image::Rgb([0, 0, 255]));

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GrayImage, Luma, Rgb, Rgba, RgbaImage};
+use image::{DynamicImage, GrayImage, Luma, Rgb, Rgba};
 use imageproc::drawing::{draw_filled_circle_mut, draw_filled_rect_mut, draw_line_segment_mut};
 use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
@@ -568,7 +568,7 @@ pub fn makevege(
 
     let scalefactor = config.scalefactor;
 
-    let underg = Rgba([64, 121, 0, 255]);
+    // factor to convert from coordinates to pixels
     let tmpfactor = (600.0 / 254.0 / scalefactor) as f32;
 
     let bf32 = block as f32;
@@ -577,10 +577,10 @@ pub fn makevege(
     let hh = hf32 * bf32;
     let mut x = 0.0_f32;
 
-    let mut imgug = RgbaImage::from_pixel(
+    let mut imgug = OurImage::new(
         (w_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
         (h_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
-        Rgba([255, 255, 255, 0]),
+        PaletteColorEnum::Transparent.to_color(),
     );
     let mut img_ug_bit = GrayImage::from_pixel(
         (w_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
@@ -612,7 +612,7 @@ pub fn makevege(
                         tmpfactor * (x + bf32 * 3.0),
                         tmpfactor * (hf32 * bf32 - y + bf32 * 3.0),
                     ),
-                    underg,
+                    PaletteColorEnum::Undergrowth.to_color(),
                 );
                 draw_line_segment_mut(
                     &mut imgug,
@@ -624,7 +624,7 @@ pub fn makevege(
                         tmpfactor * (x + bf32 * 3.0) + 1.0,
                         tmpfactor * (hf32 * bf32 - y + bf32 * 3.0),
                     ),
-                    underg,
+                    PaletteColorEnum::Undergrowth.to_color(),
                 );
                 draw_line_segment_mut(
                     &mut imgug,
@@ -636,7 +636,7 @@ pub fn makevege(
                         tmpfactor * (x - bf32 * 3.0),
                         tmpfactor * (hf32 * bf32 - y + bf32 * 3.0),
                     ),
-                    underg,
+                    PaletteColorEnum::Undergrowth.to_color(),
                 );
                 draw_line_segment_mut(
                     &mut imgug,
@@ -648,7 +648,7 @@ pub fn makevege(
                         tmpfactor * (x - bf32 * 3.0) + 1.0,
                         tmpfactor * (hf32 * bf32 - y + bf32 * 3.0),
                     ),
-                    underg,
+                    PaletteColorEnum::Undergrowth.to_color(),
                 );
 
                 if vege_bitmode {
@@ -668,7 +668,7 @@ pub fn makevege(
                     &mut imgug,
                     (tmpfactor * x, tmpfactor * (hf32 * bf32 - y - bf32 * 3.0)),
                     (tmpfactor * x, tmpfactor * (hf32 * bf32 - y + bf32 * 3.0)),
-                    underg,
+                    PaletteColorEnum::Undergrowth.to_color(),
                 );
                 draw_line_segment_mut(
                     &mut imgug,
@@ -680,7 +680,7 @@ pub fn makevege(
                         tmpfactor * x + 1.0,
                         tmpfactor * (hf32 * bf32 - y + bf32 * 3.0),
                     ),
-                    underg,
+                    PaletteColorEnum::Undergrowth.to_color(),
                 );
 
                 if vege_bitmode {
@@ -705,7 +705,7 @@ pub fn makevege(
             &mut fs
                 .create(tmpfolder.join("undergrowth.png"))
                 .expect("error saving png"),
-            image::ImageFormat::Png,
+            &palette,
         )
         .expect("could not save output png");
 

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -13,6 +13,7 @@ use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
+use crate::palette::{OurImage, Palette, PaletteColorEnum};
 use crate::vec2d::Vec2D;
 
 pub fn makevege(
@@ -29,6 +30,8 @@ pub fn makevege(
     // in world coordinates
     let size = hmap.scale;
     let xyz = &hmap.grid;
+
+    let palette = Palette::new(config);
 
     let thresholds = &config.thresholds;
     let block = config.greendetectsize;
@@ -247,8 +250,11 @@ pub fn makevege(
 
     // render yellow as multiple small squares
     let ye2 = Rgba([255, 219, 166, 255]);
-    let palette_ye = [Rgba([0, 0, 0, 0]), ye2];
-    let mut imgye2 = GrayImage::from_pixel(img_width, img_height, Luma([0]));
+    let mut imgye2 = OurImage::new(
+        img_width,
+        img_height,
+        PaletteColorEnum::BackgroundWhite.to_color(),
+    );
     for x in 0..(w_3 - 2) {
         for y in 0..(h_3 - 2) {
             let mut ghit2 = 0;
@@ -262,25 +268,13 @@ pub fn makevege(
                 }
             }
             if ghit2 as f64 / (highhit2 as f64 + ghit2 as f64 + 0.01) > yellowthreshold {
-                draw_filled_rect_mut(
-                    &mut imgye2,
+                imgye2.draw_filled_rect(
                     Rect::at(x as i32 * 3 + 2, (h_3 as i32 - y as i32) * 3 - 3).of_size(3, 3),
-                    Luma::from([1]),
+                    PaletteColorEnum::Yellow2.to_color(),
                 );
             }
         }
     }
-
-    // render green gradients
-    let greens = (0..greenshades.len())
-        .map(|i| {
-            Rgb([
-                (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
-                (254.0 - (74.0 / (greenshades.len() - 1) as f64) * i as f64) as u8,
-                (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
-            ])
-        })
-        .collect::<Vec<_>>();
 
     // compute global average firsthit
     let aveg = {
@@ -298,7 +292,17 @@ pub fn makevege(
         aveg as f64 / avecount as f64
     };
 
-    let mut imggr1 = GrayImage::from_pixel(img_width, img_height, Luma([0]));
+    // let mut imggr1 = GrayImage::from_pixel(img_width, img_height, Luma([0]));
+    // let mut imggr1 = ImageBuffer::<PaletteColor, Vec<u8>>::from_pixel(
+    //     img_width,
+    //     img_height,
+    //     PaletteColorEnum::Transparent.to_color(),
+    // );
+    let mut imggr1 = OurImage::new(
+        img_width,
+        img_height,
+        PaletteColorEnum::BackgroundWhite.to_color(),
+    );
     for x in 0..w_block {
         for y in 0..h_block {
             let roof = top[(x, y)]
@@ -344,8 +348,7 @@ pub fn makevege(
                     }
                 }
                 if greenshade > 0 {
-                    draw_filled_rect_mut(
-                        &mut imggr1,
+                    imggr1.draw_filled_rect(
                         Rect::at(
                             ((x as f64 - 0.5) * block) as i32 - addition,
                             (((h_block as f64 - y as f64) - 0.5) * block) as i32 - addition,
@@ -354,7 +357,9 @@ pub fn makevege(
                             (block as i32 + addition) as u32,
                             (block as i32 + addition) as u32,
                         ),
-                        Luma::from([greenshade as u8]),
+                        PaletteColorEnum::GreenShade(greenshade as u8 - 1).to_color(),
+                        // Luma::from([greenshade as u8]),
+                        // PaletteColor([greenshade as u8]),
                     );
                 }
             }
@@ -367,63 +372,82 @@ pub fn makevege(
     let medyellow = config.medyellow;
 
     if med > 1 {
-        imggr1 = median_filter(&imggr1, med / 2, med / 2);
+        // imggr1 = median_filter(&imggr1, med / 2, med / 2);
+        imggr1 = imggr1.median_filter(med / 2, med / 2);
     }
     if med2 > 1 {
-        imggr1 = median_filter(&imggr1, med2 / 2, med2 / 2);
+        // imggr1 = median_filter(&imggr1, med2 / 2, med2 / 2);
+        imggr1 = imggr1.median_filter(med2 / 2, med2 / 2);
     }
     if proceed_yellows {
         if med > 1 {
-            imgye2 = median_filter(&imgye2, med / 2, med / 2);
+            imgye2 = imgye2.median_filter(med / 2, med / 2);
         }
         if med2 > 1 {
-            imgye2 = median_filter(&imgye2, med2 / 2, med2 / 2);
+            imgye2 = imgye2.median_filter(med2 / 2, med2 / 2);
         }
     } else if medyellow > 1 {
-        imgye2 = median_filter(&imgye2, medyellow / 2, medyellow / 2);
+        imgye2 = imgye2.median_filter(medyellow / 2, medyellow / 2);
     }
 
     // convert to full image
-    let imgye2 = crate::util::expand_palette(imgye2, &palette_ye);
+    // let imgye2 = imgye2.to_rgba(&palette);
+    // crate::util::expand_palette(&imgye2, &palette_ye);
 
     imgye2
         .write_to(
             &mut fs
                 .create(tmpfolder.join("yellow.png"))
                 .expect("error saving png"),
-            image::ImageFormat::Png,
+            &palette,
         )
         .expect("could not save output png");
 
-    let mut palette = vec![Rgb([255, 255, 255])];
-    palette.extend(greens.iter());
+    // let mut palette = vec![Rgb([255, 255, 255])];
+    // palette.extend(greens.iter());
 
-    let imggr1 = crate::util::expand_palette(imggr1, &palette);
+    // let imggr1 = imggr1.to_rgba(&palette);
+    // crate::util::expand_palette_index(imggr1, &palette);
 
     imggr1
         .write_to(
             &mut fs
                 .create(tmpfolder.join("greens.png"))
                 .expect("error saving png"),
-            image::ImageFormat::Png,
+            &palette,
         )
         .expect("could not save output png");
 
-    let mut img = DynamicImage::ImageRgb8(imggr1);
-    image::imageops::overlay(&mut img, &DynamicImage::ImageRgba8(imgye2), 0, 0);
+    // let mut img = DynamicImage::ImageRgba8(imggr1);
+    // image::imageops::overlay(&mut imggr1, &imgye2, 0, 0);
+    imggr1.overlay(&imgye2, 0, 0);
 
-    img.write_to(
-        &mut fs
-            .create(tmpfolder.join("vegetation.png"))
-            .expect("error saving png"),
-        image::ImageFormat::Png,
-    )
-    .expect("could not save output png");
+    imggr1
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("vegetation.png"))
+                .expect("error saving png"),
+            &palette,
+            // image::ImageFormat::Png,
+        )
+        .expect("could not save output png");
 
     // drop img to free memory
-    drop(img);
+    // drop(img);
 
     if vege_bitmode {
+        // TODO: make this better
+        // render green gradients
+        let greens = (0..greenshades.len())
+            .map(|i| {
+                Rgb([
+                    (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
+                    (254.0 - (74.0 / (greenshades.len() - 1) as f64) * i as f64) as u8,
+                    (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
+                ])
+            })
+            .collect::<Vec<_>>();
+
         let g_img = fs
             .read_image_png(tmpfolder.join("greens.png"))
             .expect("Opening image failed");

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GrayAlphaImage, GrayImage, Luma, LumaA, Rgba};
+use image::{DynamicImage, GrayAlphaImage, GrayImage, Luma, LumaA};
 use imageproc::drawing::{draw_filled_circle_mut, draw_filled_rect_mut, draw_line_segment_mut};
 use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
@@ -290,12 +290,6 @@ pub fn makevege(
         aveg as f64 / avecount as f64
     };
 
-    // let mut imggr1 = GrayImage::from_pixel(img_width, img_height, Luma([0]));
-    // let mut imggr1 = ImageBuffer::<PaletteColor, Vec<u8>>::from_pixel(
-    //     img_width,
-    //     img_height,
-    //     PaletteColorEnum::Transparent.to_color(),
-    // );
     let mut imggr1 = OurImage::new(
         img_width,
         img_height,
@@ -363,6 +357,9 @@ pub fn makevege(
             }
         }
     }
+
+    // drop all used resources to free memory early
+    drop((top, firsthit, ghit, greenhit, highit, yhit, noyhit));
 
     let proceed_yellows: bool = config.proceed_yellows;
     let med: u32 = config.med;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GrayImage, Luma, Rgb, Rgba};
+use image::{DynamicImage, GrayImage, Luma, Rgba};
 use imageproc::drawing::{draw_filled_circle_mut, draw_filled_rect_mut, draw_line_segment_mut};
 use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
@@ -45,7 +45,6 @@ pub fn makevege(
         pointvolumeexponent,
         greenhigh,
         topweight,
-        greentone,
         vegezoffset: zoffset,
         uglimit,
         uglimit2,
@@ -372,11 +371,9 @@ pub fn makevege(
     let medyellow = config.medyellow;
 
     if med > 1 {
-        // imggr1 = median_filter(&imggr1, med / 2, med / 2);
         imggr1 = imggr1.median_filter(med / 2, med / 2);
     }
     if med2 > 1 {
-        // imggr1 = median_filter(&imggr1, med2 / 2, med2 / 2);
         imggr1 = imggr1.median_filter(med2 / 2, med2 / 2);
     }
     if proceed_yellows {
@@ -390,10 +387,6 @@ pub fn makevege(
         imgye2 = imgye2.median_filter(medyellow / 2, medyellow / 2);
     }
 
-    // convert to full image
-    // let imgye2 = imgye2.to_rgba(&palette);
-    // crate::util::expand_palette(&imgye2, &palette_ye);
-
     imgye2
         .write_to(
             &mut fs
@@ -402,12 +395,6 @@ pub fn makevege(
             &palette,
         )
         .expect("could not save output png");
-
-    // let mut palette = vec![Rgb([255, 255, 255])];
-    // palette.extend(greens.iter());
-
-    // let imggr1 = imggr1.to_rgba(&palette);
-    // crate::util::expand_palette_index(imggr1, &palette);
 
     imggr1
         .write_to(
@@ -418,54 +405,25 @@ pub fn makevege(
         )
         .expect("could not save output png");
 
-    // let mut img = DynamicImage::ImageRgba8(imggr1);
-    // image::imageops::overlay(&mut imggr1, &imgye2, 0, 0);
-    imggr1.overlay(&imgye2, 0, 0);
-
-    imggr1
-        .write_to(
-            &mut fs
-                .create(tmpfolder.join("vegetation.png"))
-                .expect("error saving png"),
-            &palette,
-        )
-        .expect("could not save output png");
-
-    // drop img to free memory
-    // drop(img);
-
     if vege_bitmode {
-        // TODO: make this better
-        // render green gradients
-        let greens = (0..greenshades.len())
-            .map(|i| {
-                Rgb([
-                    (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
-                    (254.0 - (74.0 / (greenshades.len() - 1) as f64) * i as f64) as u8,
-                    (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
-                ])
-            })
-            .collect::<Vec<_>>();
+        // create a new Luma image initialized with Zeros
+        let mut g_img = GrayImage::new(imggr1.width(), imggr1.height());
 
-        let g_img = fs
-            .read_image_png(tmpfolder.join("greens.png"))
-            .expect("Opening image failed");
-        let mut g_img = g_img.to_rgb8();
-        for pixel in g_img.pixels_mut() {
-            let mut found = false;
-            for (idx, color) in greens.iter().enumerate() {
-                // index starts at 2 for the first green tone
-                let c = idx as u8 + 2;
-                if pixel[0] == color[0] && pixel[1] == color[1] && pixel[2] == color[2] {
-                    *pixel = Rgb([c, c, c]);
-                    found = true;
+        // modify pixels of the new image based on the green shades
+        for (pixel, out) in imggr1.pixels().zip(g_img.pixels_mut()) {
+            // if pixel is background, just skip (already initialized to 0)
+            if *pixel == PaletteColorEnum::BackgroundWhite.to_color() {
+                continue;
+            }
+
+            // else, find the corresponding green shade and set the output pixel
+            for idx in 0..greenshades.len() {
+                if *pixel == PaletteColorEnum::GreenShade(idx as u8).to_color() {
+                    // index starts at 2 for the first green tone
+                    *out = Luma([idx as u8 + 2]);
                 }
             }
-            if !found {
-                *pixel = Rgb([0, 0, 0]);
-            }
         }
-        let g_img = DynamicImage::ImageRgb8(g_img).to_luma8();
 
         g_img
             .write_to(
@@ -512,6 +470,22 @@ pub fn makevege(
             )
             .expect("could not save output png");
     }
+
+    // overlay yellow on top of green and save as total vegetation image
+    imggr1.overlay(&imgye2, 0, 0);
+
+    imggr1
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("vegetation.png"))
+                .expect("error saving png"),
+            &palette,
+        )
+        .expect("could not save output png");
+
+    // drop images to free memory
+    drop(imggr1);
+    drop(imgye2);
 
     let mut imgwater = OurImage::new(
         img_width,

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -13,7 +13,7 @@ use crate::io::bytes::FromToBytes;
 use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
-use crate::palette::{OurImage, Palette, PaletteColorEnum};
+use crate::palette::{Palette, PaletteColorEnum, PalettedImage};
 use crate::vec2d::Vec2D;
 
 pub fn makevege(
@@ -248,7 +248,7 @@ pub fn makevege(
     let img_height = (h_block as f64 * block) as u32;
 
     // render yellow as multiple small squares
-    let mut imgye2 = OurImage::new(
+    let mut imgye2 = PalettedImage::new(
         img_width,
         img_height,
         PaletteColorEnum::BackgroundWhite.to_color(),
@@ -290,7 +290,7 @@ pub fn makevege(
         aveg as f64 / avecount as f64
     };
 
-    let mut imggr1 = OurImage::new(
+    let mut imggr1 = PalettedImage::new(
         img_width,
         img_height,
         PaletteColorEnum::BackgroundWhite.to_color(),
@@ -478,7 +478,7 @@ pub fn makevege(
     drop(imggr1);
     drop(imgye2);
 
-    let mut imgwater = OurImage::new(
+    let mut imgwater = PalettedImage::new(
         img_width,
         img_height,
         PaletteColorEnum::BackgroundWhite.to_color(),
@@ -542,7 +542,7 @@ pub fn makevege(
     let hh = hf32 * bf32;
     let mut x = 0.0_f32;
 
-    let mut imgug = OurImage::new(
+    let mut imgug = PalettedImage::new(
         (w_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
         (h_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
         PaletteColorEnum::Transparent.to_color(),

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -350,8 +350,6 @@ pub fn makevege(
                             (block as i32 + addition) as u32,
                         ),
                         PaletteColorEnum::GreenShade(greenshade as u8 - 1).to_color(),
-                        // Luma::from([greenshade as u8]),
-                        // PaletteColor([greenshade as u8]),
                     );
                 }
             }

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GrayImage, Luma, Rgba};
+use image::{DynamicImage, GrayAlphaImage, GrayImage, Luma, LumaA, Rgba};
 use imageproc::drawing::{draw_filled_circle_mut, draw_filled_rect_mut, draw_line_segment_mut};
 use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
@@ -248,7 +248,6 @@ pub fn makevege(
     let img_height = (h_block as f64 * block) as u32;
 
     // render yellow as multiple small squares
-    let ye2 = Rgba([255, 219, 166, 255]);
     let mut imgye2 = OurImage::new(
         img_width,
         img_height,
@@ -434,19 +433,13 @@ pub fn makevege(
             )
             .expect("could not save output png");
 
-        let y_img = fs
-            .read_image_png(tmpfolder.join("yellow.png"))
-            .expect("Opening image failed");
-        let mut y_img = y_img.to_rgba8();
-        for pixel in y_img.pixels_mut() {
-            if pixel[0] == ye2[0] && pixel[1] == ye2[1] && pixel[2] == ye2[2] && pixel[3] == ye2[3]
-            {
-                *pixel = Rgba([1, 1, 1, 255]);
-            } else {
-                *pixel = Rgba([0, 0, 0, 0]);
+        let mut y_img = GrayAlphaImage::new(imgye2.width(), imgye2.height());
+
+        for (pixel, out) in imgye2.pixels().zip(y_img.pixels_mut()) {
+            if *pixel == PaletteColorEnum::Yellow2.to_color() {
+                *out = LumaA([1, 255]);
             }
         }
-        let y_img = DynamicImage::ImageRgba8(y_img).to_luma_alpha8();
 
         y_img
             .write_to(
@@ -457,6 +450,7 @@ pub fn makevege(
             )
             .expect("could not save output png");
 
+        // overlay the two bit images (yellow on top of green) and save as vegetation bit image
         let mut img_bit = DynamicImage::ImageLuma8(g_img);
         let img_bit2 = DynamicImage::ImageLumaA8(y_img);
         image::imageops::overlay(&mut img_bit, &img_bit2, 0, 0);

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GrayImage, Luma, Rgb, RgbImage, Rgba, RgbaImage};
+use image::{DynamicImage, GrayImage, Luma, Rgb, Rgba, RgbaImage};
 use imageproc::drawing::{draw_filled_circle_mut, draw_filled_rect_mut, draw_line_segment_mut};
 use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
@@ -428,7 +428,6 @@ pub fn makevege(
                 .create(tmpfolder.join("vegetation.png"))
                 .expect("error saving png"),
             &palette,
-            // image::ImageFormat::Png,
         )
         .expect("could not save output png");
 
@@ -455,6 +454,7 @@ pub fn makevege(
         for pixel in g_img.pixels_mut() {
             let mut found = false;
             for (idx, color) in greens.iter().enumerate() {
+                // index starts at 2 for the first green tone
                 let c = idx as u8 + 2;
                 if pixel[0] == color[0] && pixel[1] == color[1] && pixel[2] == color[2] {
                     *pixel = Rgb([c, c, c]);
@@ -513,9 +513,11 @@ pub fn makevege(
             .expect("could not save output png");
     }
 
-    let mut imgwater = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
-    let black = Rgb([0, 0, 0]);
-    let blue = Rgb([29, 190, 255]);
+    let mut imgwater = OurImage::new(
+        img_width,
+        img_height,
+        PaletteColorEnum::BackgroundWhite.to_color(),
+    );
     let buildings = config.buildings;
     let water = config.water;
     if buildings > 0 || water > 0 {
@@ -529,14 +531,14 @@ pub fn makevege(
                     draw_filled_rect_mut(
                         &mut imgwater,
                         Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
-                        black,
+                        PaletteColorEnum::Black.to_color(),
                     );
                 }
                 if c == water {
                     draw_filled_rect_mut(
                         &mut imgwater,
                         Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
-                        blue,
+                        PaletteColorEnum::Blue.to_color(),
                     );
                 }
             }
@@ -548,7 +550,7 @@ pub fn makevege(
             draw_filled_rect_mut(
                 &mut imgwater,
                 Rect::at((x - xmin) as i32 - 1, (ymax - y) as i32 - 1).of_size(3, 3),
-                blue,
+                PaletteColorEnum::Blue.to_color(),
             );
         }
     }
@@ -558,7 +560,7 @@ pub fn makevege(
             &mut fs
                 .create(tmpfolder.join("blueblack.png"))
                 .expect("error saving png"),
-            image::ImageFormat::Png,
+            &palette,
         )
         .expect("could not save output png");
 


### PR DESCRIPTION
A follow-up to #247, following my comment (https://github.com/karttapullautin/karttapullautin/issues/210#issuecomment-4290382865) in #210 to generate indexed PNGs instead of RGB(A) images when rendering.

This simplifies the rendering making it faster, and also makes it use much less RAM.

Yes, it adds some extra logic to handle the color palette which is created based on the user configuration and hard-coded values, but it is a one-time setup and can then be used througout the entire rendering pipeline. As a bonus the output files thake up less disk space as well.

This PR converts the vegetation generation to use these indexed PNGs.

Regression tests pass even though it says that the image files differ. That is fine since the format of the image files has changed, while their image content has not. 