### PR TITLE
feat: list input files early to avoid TOCTOU problem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod io;
 pub mod knolls;
 pub mod merge;
 pub mod palette;
+mod plan;
 pub mod process;
 pub mod render;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,6 @@ fn main() {
         .unwrap();
         return;
     }
-    let proc = config.processes;
     if command.is_empty() && batch {
         let Config { lazfolder, .. } = &*config;
 
@@ -389,7 +388,7 @@ fn main() {
                 fs.load_from_disk(path, path).unwrap();
             }
 
-            pullauta::process::launch_threads(fs.clone(), proc, &config, &zip_files);
+            pullauta::process::launch_threads(fs.clone(), config.clone(), &zip_files);
 
             // copy the output files back to disk
             std::fs::create_dir_all(&config.batchoutfolder).unwrap();
@@ -398,7 +397,7 @@ fn main() {
                 fs.save_to_disk(&path, &path).unwrap();
             }
         } else {
-            pullauta::process::launch_threads(fs, proc, &config, &zip_files);
+            pullauta::process::launch_threads(fs, config, &zip_files);
         }
         return;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ fn main() {
                 fs.load_from_disk(path, path).unwrap();
             }
 
-            pullauta::process::launch_threads(fs.clone(), config.clone(), &zip_files);
+            pullauta::process::launch_threads(fs.clone(), config.clone(), &zip_files).unwrap();
 
             // copy the output files back to disk
             std::fs::create_dir_all(&config.batchoutfolder).unwrap();
@@ -397,7 +397,7 @@ fn main() {
                 fs.save_to_disk(&path, &path).unwrap();
             }
         } else {
-            pullauta::process::launch_threads(fs, config, &zip_files);
+            pullauta::process::launch_threads(fs, config, &zip_files).unwrap();
         }
         return;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,11 @@ use log::info;
 use pullauta::config::Config;
 use pullauta::io::fs::FileSystem;
 use pullauta::io::fs::memory::MemoryFileSystem;
-use pullauta::shapefile;
 use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::{thread, time};
 fn main() {
     // setup and configure logging, default to INFO when RUST_LOG is not set
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -361,38 +359,6 @@ fn main() {
     }
     let proc = config.processes;
     if command.is_empty() && batch {
-        // inner function to reduce code duplication
-        fn launch_threads<F: FileSystem + Send + Clone + 'static>(
-            fs: F,
-            proc: u64,
-            config: &Arc<Config>,
-            zip_files: &[String],
-        ) {
-            let shapefiletmpdir = PathBuf::from("temp_shapefiles".to_string());
-            fs.create_dir_all(&shapefiletmpdir).unwrap();
-            if !zip_files.is_empty() {
-                crate::shapefile::unzip_shapefiles(&fs, zip_files).unwrap();
-            }
-            // do the processing
-            let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity((proc + 1) as usize);
-            for i in 0..proc {
-                let config = config.clone();
-                let fs = fs.clone();
-                let has_zip = !zip_files.is_empty();
-                let handle = thread::spawn(move || {
-                    info!("Starting thread");
-                    pullauta::process::batch_process(&config, &fs, &format!("{}", i + 1), has_zip);
-                    info!("Thread complete");
-                });
-                thread::sleep(time::Duration::from_millis(100));
-                handles.push(handle);
-            }
-            for handle in handles {
-                handle.join().unwrap();
-            }
-            fs.remove_dir_all(&shapefiletmpdir).unwrap();
-        }
-
         let Config { lazfolder, .. } = &*config;
 
         let mut zip_files: Vec<String> = Vec::new();
@@ -423,7 +389,7 @@ fn main() {
                 fs.load_from_disk(path, path).unwrap();
             }
 
-            launch_threads(fs.clone(), proc, &config, &zip_files);
+            pullauta::process::launch_threads(fs.clone(), proc, &config, &zip_files);
 
             // copy the output files back to disk
             std::fs::create_dir_all(&config.batchoutfolder).unwrap();
@@ -432,7 +398,7 @@ fn main() {
                 fs.save_to_disk(&path, &path).unwrap();
             }
         } else {
-            launch_threads(fs, proc, &config, &zip_files);
+            pullauta::process::launch_threads(fs, proc, &config, &zip_files);
         }
         return;
     }
@@ -469,7 +435,6 @@ fn main() {
                 &config,
                 &thread,
                 &tmpfolder,
-                // Path::new(&command),
                 Path::new("input.laz"),
                 norender,
             )

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,0 +1,80 @@
+//! This module contains logic for planning the processing execution.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+
+use crate::io::fs::FileSystem;
+
+pub struct Plan {
+    input_files: Vec<InputFile>,
+    files_to_process: Vec<InputFileIndex>,
+}
+
+pub struct InputFile {
+    pub path: PathBuf,
+    pub output_path: PathBuf,
+    // TODO: add bounds etc
+}
+
+#[derive(Clone, Copy)]
+pub struct InputFileIndex(usize);
+
+impl Plan {
+    pub fn new_from_input_files<F: FileSystem + Send + Clone + 'static>(
+        fs: F,
+        input_folder: &str,
+        output_folder: &str,
+    ) -> anyhow::Result<Self> {
+        // list all the files that we have to process
+        let mut laz_files: Vec<PathBuf> = Vec::new();
+        for path in fs.list(input_folder).context("listing input files")? {
+            if let Some(extension) = path.extension() {
+                if extension == "laz" || extension == "las" {
+                    laz_files.push(path);
+                }
+            }
+        }
+
+        let mut input_files: Vec<InputFile> = Vec::with_capacity(laz_files.len());
+        for path in laz_files {
+            let output_path = PathBuf::from(output_folder)
+                .join(path.file_name().context("input filename")?)
+                .with_extension("png");
+
+            input_files.push(InputFile { path, output_path })
+        }
+
+        // now check if teir corresponding output files already exist, and if so, skip them
+        let mut files_to_process: Vec<InputFileIndex> = Vec::with_capacity(input_files.len());
+        for (i, input_file) in input_files.iter().enumerate() {
+            if !fs.exists(&input_file.output_path) {
+                files_to_process.push(InputFileIndex(i));
+            }
+        }
+
+        log::info!(
+            "Found {} input files, {} of which need to be processed",
+            input_files.len(),
+            files_to_process.len()
+        );
+
+        Ok(Self {
+            input_files,
+            files_to_process,
+        })
+    }
+
+    pub fn get_input_file(&self, index: InputFileIndex) -> &InputFile {
+        &self.input_files[index.0]
+    }
+
+    pub fn input_files(&self) -> &[InputFile] {
+        &self.input_files
+    }
+
+    pub fn files_to_process(&self) -> &[InputFileIndex] {
+        &self.files_to_process
+    }
+}
+

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -77,4 +77,3 @@ impl Plan {
         &self.files_to_process
     }
 }
-

--- a/src/process.rs
+++ b/src/process.rs
@@ -88,8 +88,8 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
 
     // we can now start sending the files to process to the threads
     for laz in plan.files_to_process() {
-        // TODO: send only the ids of the files
-        tx.push(laz.clone());
+        // send only the ids of the files
+        tx.push(*laz);
     }
 
     // we are done, close the producer and wait for all threads to exit
@@ -697,7 +697,7 @@ pub fn batch_process(
             )
             .expect("could not save output png");
 
-            fs.copy(format!("pullautus{thread}.png"), &outfile)
+            fs.copy(format!("pullautus{thread}.png"), outfile)
                 .expect("Could not copy file to output folder");
             fs.copy(
                 format!("pullautus{thread}.pgw"),

--- a/src/process.rs
+++ b/src/process.rs
@@ -486,7 +486,7 @@ pub fn batch_process(
     while let Some(laz_path) = rx.pop() {
         let file_to_process = plan.get_input_file(laz_path);
         let infile = file_to_process.path.as_path();
-        let laz = infile.file_name().unwrap().to_str().unwrap();
+        let laz = infile.file_stem().unwrap().to_str().unwrap();
         let outfile = file_to_process.output_path.as_path();
 
         info!("{} -> {}", infile.display(), outfile.display());

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use image::{GrayImage, Luma, Rgb, RgbImage, Rgba, RgbaImage};
 use las::{Reader, raw::Header};
 use log::debug;
@@ -21,6 +22,8 @@ use crate::io::xyz::XyzInternalWriter;
 use crate::io::xyz::XyzRecord;
 use crate::knolls;
 use crate::merge;
+use crate::plan::InputFileIndex;
+use crate::plan::Plan;
 use crate::render;
 use crate::util::Consumer;
 use crate::util::Timing;
@@ -38,7 +41,7 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     fs: F,
     config: Arc<Config>,
     zip_files: &[String],
-) {
+) -> anyhow::Result<()> {
     // first unzip all zip files (if any) to a temporary folder, so that the threads can access the
     // shapefiles without having to worry about unzipping them in parallel
     let shapefiletmpdir = PathBuf::from("temp_shapefiles".to_string());
@@ -47,33 +50,24 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         crate::shapefile::unzip_shapefiles(&fs, zip_files).unwrap();
     }
 
-    // list all the files that we have to process
+    let plan = crate::plan::Plan::new_from_input_files(
+        fs.clone(),
+        &config.lazfolder,
+        &config.batchoutfolder,
+    )
+    .context("creating plan")?;
 
-    let mut laz_files: Vec<PathBuf> = Vec::new();
-    for path in fs.list(&config.lazfolder).unwrap() {
-        if let Some(extension) = path.extension() {
-            if extension == "laz" || extension == "las" {
-                laz_files.push(path);
-            }
-        }
-    }
-
-    info!("Found {} laz/las files to process", laz_files.len());
-
-    // TODO: check which files are alredy processed
-
-    // TODO: build universe by loading all headers etc here already
-    let laz_files = Arc::new(laz_files);
+    let plan = Arc::new(plan);
 
     // insert them into the queue
-    let (tx, rx) = crate::util::make_queue::<PathBuf>();
+    let (tx, rx) = crate::util::make_queue::<InputFileIndex>();
 
     // make sure the output directory exists
     fs.create_dir_all(&config.batchoutfolder)
         .expect("Could not create output folder");
 
     // we only need to launch maximum as many threads as there are files to process
-    let num_threads = config.processes.min(laz_files.len() as u64) as usize;
+    let num_threads = config.processes.min(plan.files_to_process().len() as u64) as usize;
 
     // do the processing
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(num_threads);
@@ -82,25 +76,18 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         let fs = fs.clone();
         let rx = rx.clone();
         let has_zip = !zip_files.is_empty();
-        let arc_laz_files = laz_files.clone();
+        let arc_plan = plan.clone();
 
         let handle = thread::spawn(move || {
             info!("Starting thread");
-            batch_process(
-                &config,
-                &fs,
-                &format!("{}", i + 1),
-                has_zip,
-                &arc_laz_files,
-                rx,
-            );
+            batch_process(&config, &fs, &format!("{}", i + 1), has_zip, arc_plan, rx);
         });
         thread::sleep(std::time::Duration::from_millis(100));
         handles.push(handle);
     }
 
     // we can now start sending the files to process to the threads
-    for laz in laz_files.iter() {
+    for laz in plan.files_to_process() {
         // TODO: send only the ids of the files
         tx.push(laz.clone());
     }
@@ -113,6 +100,7 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
 
     // cleanup extracted shapefiles
     fs.remove_dir_all(&shapefiletmpdir).unwrap();
+    Ok(())
 }
 
 pub fn process_zip(
@@ -467,8 +455,8 @@ pub fn batch_process(
     fs: &impl FileSystem,
     thread: &String,
     has_zip: bool,
-    laz_files: &[PathBuf],
-    rx: Consumer<PathBuf>,
+    plan: Arc<Plan>,
+    rx: Consumer<InputFileIndex>,
 ) {
     let &Config {
         vegeonly,
@@ -483,11 +471,7 @@ pub fn batch_process(
         ..
     } = conf;
 
-    let Config {
-        lazfolder,
-        batchoutfolder,
-        ..
-    } = conf;
+    let Config { batchoutfolder, .. } = conf;
 
     let mut rng = rand::rng();
     let randdist = rand::distr::Bernoulli::new(thinfactor).unwrap();
@@ -500,22 +484,14 @@ pub fn batch_process(
 
     // take input files from queue until there are no more
     while let Some(laz_path) = rx.pop() {
-        let laz = laz_path.file_name().unwrap().to_str().unwrap();
-        let outfile = format!("{batchoutfolder}/{laz}.png");
-        if fs.exists(&outfile) {
-            info!("Skipping {laz}.png it exists already in output folder.");
-            continue;
-        }
+        let file_to_process = plan.get_input_file(laz_path);
+        let infile = file_to_process.path.as_path();
+        let laz = infile.file_name().unwrap().to_str().unwrap();
+        let outfile = file_to_process.output_path.as_path();
 
-        info!("{laz} -> {laz}.png");
-        fs.create(&outfile).unwrap();
+        info!("{} -> {}", infile.display(), outfile.display());
 
-        let headerfile = PathBuf::from(format!("header{thread}.xyz"));
-        if fs.exists(&headerfile) {
-            fs.remove_file(&headerfile).unwrap();
-        }
-
-        let mut file = fs.open(format!("{lazfolder}/{laz}")).unwrap();
+        let mut file = fs.open(infile).unwrap();
         let header = Header::read_from(&mut file).unwrap();
         let minx = header.min_x;
         let miny = header.min_y;
@@ -533,9 +509,9 @@ pub fn batch_process(
             XyzInternalWriter::new(fs.create(&tmp_filename).expect("Could not create writer"));
 
         // read points from all LAZ files that have an overlap with the main tile file
-        for laz_p in laz_files {
-            let laz = laz_p.as_path().file_name().unwrap().to_str().unwrap();
-            let mut file = fs.open(format!("{lazfolder}/{laz}")).unwrap();
+        for laz_p in plan.input_files() {
+            let laz_p = &laz_p.path;
+            let mut file = fs.open(laz_p).unwrap();
             let header = Header::read_from(&mut file).unwrap();
             if header.max_x > minx2
                 && header.min_x < maxx2

--- a/src/process.rs
+++ b/src/process.rs
@@ -7,6 +7,8 @@ use std::error::Error;
 use std::io::BufRead;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
 
 use crate::blocks;
 use crate::cliffs;
@@ -27,6 +29,40 @@ use crate::vegetation;
 // compute the number of elements we can buffer for 50MB of memory usage during LAZ -> XyzRecord conversion
 const LAZ_BUFFER_SIZE: usize =
     50 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
+
+/// Launches threads and coordinates the logic for processing multiple files in parallell.
+/// When it returns, all files have been processed and output files have been generated according to
+/// the Config.
+pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
+    fs: F,
+    proc: u64,
+    config: &Arc<Config>,
+    zip_files: &[String],
+) {
+    let shapefiletmpdir = PathBuf::from("temp_shapefiles".to_string());
+    fs.create_dir_all(&shapefiletmpdir).unwrap();
+    if !zip_files.is_empty() {
+        crate::shapefile::unzip_shapefiles(&fs, zip_files).unwrap();
+    }
+    // do the processing
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity((proc + 1) as usize);
+    for i in 0..proc {
+        let config = config.clone();
+        let fs = fs.clone();
+        let has_zip = !zip_files.is_empty();
+        let handle = thread::spawn(move || {
+            info!("Starting thread");
+            batch_process(&config, &fs, &format!("{}", i + 1), has_zip);
+            info!("Thread complete");
+        });
+        thread::sleep(std::time::Duration::from_millis(100));
+        handles.push(handle);
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    fs.remove_dir_all(&shapefiletmpdir).unwrap();
+}
 
 pub fn process_zip(
     fs: &impl FileSystem,

--- a/src/process.rs
+++ b/src/process.rs
@@ -22,6 +22,7 @@ use crate::io::xyz::XyzRecord;
 use crate::knolls;
 use crate::merge;
 use crate::render;
+use crate::util::Consumer;
 use crate::util::Timing;
 use crate::util::read_lines_no_alloc;
 use crate::vegetation;
@@ -35,32 +36,82 @@ const LAZ_BUFFER_SIZE: usize =
 /// the Config.
 pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     fs: F,
-    proc: u64,
-    config: &Arc<Config>,
+    config: Arc<Config>,
     zip_files: &[String],
 ) {
+    // first unzip all zip files (if any) to a temporary folder, so that the threads can access the
+    // shapefiles without having to worry about unzipping them in parallel
     let shapefiletmpdir = PathBuf::from("temp_shapefiles".to_string());
     fs.create_dir_all(&shapefiletmpdir).unwrap();
     if !zip_files.is_empty() {
         crate::shapefile::unzip_shapefiles(&fs, zip_files).unwrap();
     }
+
+    // list all the files that we have to process
+
+    let mut laz_files: Vec<PathBuf> = Vec::new();
+    for path in fs.list(&config.lazfolder).unwrap() {
+        if let Some(extension) = path.extension() {
+            if extension == "laz" || extension == "las" {
+                laz_files.push(path);
+            }
+        }
+    }
+
+    info!("Found {} laz/las files to process", laz_files.len());
+
+    // TODO: check which files are alredy processed
+
+    // TODO: build universe by loading all headers etc here already
+    let laz_files = Arc::new(laz_files);
+
+    // insert them into the queue
+    let (tx, rx) = crate::util::make_queue::<PathBuf>();
+
+    // make sure the output directory exists
+    fs.create_dir_all(&config.batchoutfolder)
+        .expect("Could not create output folder");
+
+    // we only need to launch maximum as many threads as there are files to process
+    let num_threads = config.processes.min(laz_files.len() as u64) as usize;
+
     // do the processing
-    let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity((proc + 1) as usize);
-    for i in 0..proc {
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(num_threads);
+    for i in 0..num_threads {
         let config = config.clone();
         let fs = fs.clone();
+        let rx = rx.clone();
         let has_zip = !zip_files.is_empty();
+        let arc_laz_files = laz_files.clone();
+
         let handle = thread::spawn(move || {
             info!("Starting thread");
-            batch_process(&config, &fs, &format!("{}", i + 1), has_zip);
-            info!("Thread complete");
+            batch_process(
+                &config,
+                &fs,
+                &format!("{}", i + 1),
+                has_zip,
+                &arc_laz_files,
+                rx,
+            );
         });
         thread::sleep(std::time::Duration::from_millis(100));
         handles.push(handle);
     }
+
+    // we can now start sending the files to process to the threads
+    for laz in laz_files.iter() {
+        // TODO: send only the ids of the files
+        tx.push(laz.clone());
+    }
+
+    // we are done, close the producer and wait for all threads to exit
+    drop(tx);
     for handle in handles {
         handle.join().unwrap();
     }
+
+    // cleanup extracted shapefiles
     fs.remove_dir_all(&shapefiletmpdir).unwrap();
 }
 
@@ -411,7 +462,14 @@ pub fn process_tile(
     Ok(())
 }
 
-pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_zip: bool) {
+pub fn batch_process(
+    conf: &Config,
+    fs: &impl FileSystem,
+    thread: &String,
+    has_zip: bool,
+    laz_files: &[PathBuf],
+    rx: Consumer<PathBuf>,
+) {
     let &Config {
         vegeonly,
         cliffsonly,
@@ -434,25 +492,14 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
     let mut rng = rand::rng();
     let randdist = rand::distr::Bernoulli::new(thinfactor).unwrap();
 
-    fs.create_dir_all(batchoutfolder)
-        .expect("Could not create output folder");
-
-    let mut laz_files: Vec<PathBuf> = Vec::new();
-    for path in fs.list(lazfolder).unwrap() {
-        if let Some(extension) = path.extension() {
-            if extension == "laz" || extension == "las" {
-                laz_files.push(path);
-            }
-        }
-    }
-
     let options = las::ReaderOptions::default().with_laz_parallelism(if conf.laz_parallel {
         las::LazParallelism::Yes
     } else {
         las::LazParallelism::No
     });
 
-    for laz_path in &laz_files {
+    // take input files from queue until there are no more
+    while let Some(laz_path) = rx.pop() {
         let laz = laz_path.file_name().unwrap().to_str().unwrap();
         let outfile = format!("{batchoutfolder}/{laz}.png");
         if fs.exists(&outfile) {
@@ -486,7 +533,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String, has_z
             XyzInternalWriter::new(fs.create(&tmp_filename).expect("Could not create writer"));
 
         // read points from all LAZ files that have an overlap with the main tile file
-        for laz_p in &laz_files {
+        for laz_p in laz_files {
             let laz = laz_p.as_path().file_name().unwrap().to_str().unwrap();
             let mut file = fs.open(format!("{lazfolder}/{laz}")).unwrap();
             let header = Header::read_from(&mut file).unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,9 @@
 use std::{
+    collections::VecDeque,
     fmt::Debug,
     io::{self, BufRead},
     path::Path,
+    sync::{Arc, Condvar, Mutex},
     time::Instant,
 };
 
@@ -151,4 +153,149 @@ pub fn write_object<W: std::io::Write, O: serde::Serialize>(
     )
     .context("serializing to file")?;
     Ok(())
+}
+
+/// A simple Single-Producer-Multiple-Consumer queue for passing work to processing threads.
+pub fn make_queue<T>() -> (Producer<T>, Consumer<T>) {
+    let inner = Inner {
+        inner: Mutex::new(InnerMut {
+            queue: VecDeque::new(),
+            has_closed: false,
+        }),
+        var_has_items: Condvar::new(),
+    };
+    let inner = Arc::new(inner);
+
+    let producer = Producer {
+        inner: Arc::clone(&inner),
+    };
+    let consumer = Consumer { inner };
+    (producer, consumer)
+}
+
+struct Inner<T> {
+    inner: Mutex<InnerMut<T>>,
+    var_has_items: Condvar,
+}
+
+struct InnerMut<T> {
+    queue: VecDeque<T>,
+    has_closed: bool,
+}
+
+pub struct Producer<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> Producer<T> {
+    /// Pushes an item to the queue. Returns `Err` if the queue has been closed.
+    pub fn push(&self, item: T) {
+        let mut inner = self.inner.inner.lock().unwrap();
+        inner.queue.push_back(item);
+        self.inner.var_has_items.notify_one();
+    }
+}
+
+impl<T> Drop for Producer<T> {
+    fn drop(&mut self) {
+        let mut inner = self.inner.inner.lock().unwrap();
+        inner.has_closed = true;
+        self.inner.var_has_items.notify_all();
+    }
+}
+
+#[derive(Clone)]
+pub struct Consumer<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> Consumer<T> {
+    /// Pops an item from the queue. Returns `None` if the queue has been closed and is empty.
+    pub fn pop(&self) -> Option<T> {
+        let mut inner = self.inner.inner.lock().unwrap();
+        loop {
+            if let Some(item) = inner.queue.pop_front() {
+                return Some(item);
+            }
+            if inner.has_closed {
+                return None;
+            }
+            inner = self.inner.var_has_items.wait(inner).unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_queue() {
+        let (producer, consumer) = make_queue();
+
+        let producer_thread = thread::spawn(move || {
+            for i in 0..10 {
+                producer.push(i);
+            }
+        });
+
+        let consumer_thread = thread::spawn(move || {
+            let mut items = Vec::new();
+            while let Some(item) = consumer.pop() {
+                items.push(item);
+            }
+            items
+        });
+
+        producer_thread.join().unwrap();
+        let items = consumer_thread.join().unwrap();
+        assert_eq!(items, (0..10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_multiple_consumer() {
+        let (producer, consumer) = make_queue();
+
+        let producer_thread = thread::spawn(move || {
+            for i in 0..10 {
+                producer.push(i);
+            }
+        });
+
+        let consumer_thread1 = thread::spawn({
+            let consumer = consumer.clone();
+            move || {
+                let mut items = Vec::new();
+                while let Some(item) = consumer.pop() {
+                    items.push(item);
+                }
+                items
+            }
+        });
+
+        let consumer_thread2 = thread::spawn({
+            let consumer = consumer.clone();
+            move || {
+                let mut items = Vec::new();
+                while let Some(item) = consumer.pop() {
+                    items.push(item);
+                }
+                items
+            }
+        });
+
+        producer_thread.join().unwrap();
+        let items1 = consumer_thread1.join().unwrap();
+        let items2 = consumer_thread2.join().unwrap();
+
+        assert_eq!(items1.len() + items2.len(), 10);
+        assert_eq!(
+            [items1, items2]
+                .concat()
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>(),
+            (0..10).collect::<std::collections::HashSet<_>>()
+        );
+    }
 }


### PR DESCRIPTION
As mentioned in #246 , we currently have a Time-of-check time-of-use problem where each processing thread independently decides which output file to process next. This PR fixes that by listing all the input files once at the beginning and checking which ones that need processing. The files to process are then sent to the worker threads. 

We go from a model where each thread was acting alone/"solo", to a model where the main thread coordinate the processing with the worker threads. This allows us to implement smarter execution planning in the future :rocket: