### PR TITLE
feat: refactor batch processing to allow smarter LAZ reading

### DIFF
--- a/src/io/fs/local.rs
+++ b/src/io/fs/local.rs
@@ -67,6 +67,11 @@ impl FileSystem for LocalFileSystem {
         Ok(())
     }
 
+    fn rename(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {
+        std::fs::rename(from, to)?;
+        Ok(())
+    }
+
     fn extract_zip(
         &self,
         archive: impl AsRef<Path>,

--- a/src/io/fs/memory.rs
+++ b/src/io/fs/memory.rs
@@ -445,6 +445,12 @@ impl FileSystem for MemoryFileSystem {
         Ok(())
     }
 
+    fn rename(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {
+        self.copy(&from, to)?;
+        self.remove_file(from)?;
+        Ok(())
+    }
+
     fn extract_zip(
         &self,
         archive: impl AsRef<Path>,

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -41,6 +41,9 @@ pub trait FileSystem: std::fmt::Debug {
     /// Copy a file.
     fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error>;
 
+    /// Move a file.
+    fn rename(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error>;
+
     /// Extract a ZIP archive to a directory.
     fn extract_zip(
         &self,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,5 +1,6 @@
 //! This module contains logic for planning the processing execution.
 
+use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context;
@@ -35,7 +36,7 @@ impl Plan {
         fs: F,
         input_folder: &str,
         output_folder: &str,
-        staging_folder: &str,
+        staging_folder: &Path,
         padding: f64,
     ) -> anyhow::Result<Self> {
         // list all the files that we have to process

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -133,21 +133,23 @@ fn mapping_from_headers(
 ) -> HashMap<InputFileIndex, HashSet<InputFileIndex>> {
     let mut mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>> = HashMap::default();
 
-    // this is now O(n^2) but we expect n to be small, and it is simpler to implement than a spatial index
+    // This is now O(n^2) but we expect n to be small, and it is simpler to
+    // implement than a spatial index. Check each pair only once because the
+    // overlap relation is symmetric when both bounds use the same padding.
     for (i, ih) in headers.iter().enumerate() {
+        mapping.entry(InputFileIndex(i)).or_default();
+
         let padded_bounds = ih.header.bounds.expand(padding);
-
-        let e = mapping.entry(InputFileIndex(i)).or_default();
-
-        for (j, jh) in headers.iter().enumerate() {
-            // skip self
-            if i == j {
-                continue;
-            }
-
-            // if overlap, there is a dependency (in both directions!)
+        for (j, jh) in headers.iter().enumerate().skip(i + 1) {
             if jh.header.bounds.overlaps(&padded_bounds) {
-                e.insert(InputFileIndex(j));
+                mapping
+                    .entry(InputFileIndex(i))
+                    .or_default()
+                    .insert(InputFileIndex(j));
+                mapping
+                    .entry(InputFileIndex(j))
+                    .or_default()
+                    .insert(InputFileIndex(i));
             }
         }
     }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -137,6 +137,8 @@ fn mapping_from_headers(
     // implement than a spatial index. Check each pair only once because the
     // overlap relation is symmetric when both bounds use the same padding.
     for (i, ih) in headers.iter().enumerate() {
+        // make sure each file is represented in the mapping, even if there
+        // are no neighboring files (eg. if the set is empty)
         mapping.entry(InputFileIndex(i)).or_default();
 
         let padded_bounds = ih.header.bounds.expand(padding);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -205,9 +205,7 @@ impl NaivePlanner {
 impl Planner for NaivePlanner {
     fn next_operation(&mut self) -> Option<Vec<Operation>> {
         // take the first key and process it
-        let Some(&i) = self.mapping.keys().next() else {
-            return None;
-        };
+        let &i = self.mapping.keys().next()?;
 
         // construct operations to perform:
         let mut ops = Vec::new();
@@ -255,9 +253,7 @@ impl ExtractOncePlanner {
 impl Planner for ExtractOncePlanner {
     fn next_operation(&mut self) -> Option<Vec<Operation>> {
         // take the file with lowest number of dependencies (or just the first one if there are multiple)
-        let Some((&i, deps)) = self.mapping.iter().min_by_key(|(_, deps)| deps.len()) else {
-            return None;
-        };
+        let (&i, deps) = self.mapping.iter().min_by_key(|(_, deps)| deps.len())?;
 
         // // TODO: we could sort by fewest amount of total points to process as well...
         // let n_points_total = mapping

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -3,21 +3,31 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
+use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashSet as HashSet;
 
 use crate::io::fs::FileSystem;
 
 pub struct Plan {
     input_files: Vec<InputFile>,
     files_to_process: Vec<InputFileIndex>,
+    mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>>,
 }
 
 pub struct InputFile {
+    /// Path of the input LAS/LAZ file
     pub path: PathBuf,
+    /// Path of the output PNG
     pub output_path: PathBuf,
-    // TODO: add bounds etc
+
+    /// Path of the temporary .xyz.bin file to store points in
+    pub staging_path: PathBuf,
+
+    /// The header read from the input file
+    pub header: Header,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct InputFileIndex(usize);
 
 impl Plan {
@@ -25,6 +35,8 @@ impl Plan {
         fs: F,
         input_folder: &str,
         output_folder: &str,
+        staging_folder: &str,
+        padding: f64,
     ) -> anyhow::Result<Self> {
         // list all the files that we have to process
         let mut laz_files: Vec<PathBuf> = Vec::new();
@@ -36,20 +48,47 @@ impl Plan {
             }
         }
 
+        // sort for deterministic processing order (not strictly needed, but makes it easier to debug and test)
+        laz_files.sort();
+
         let mut input_files: Vec<InputFile> = Vec::with_capacity(laz_files.len());
         for path in laz_files {
             let output_path = PathBuf::from(output_folder)
                 .join(path.file_name().context("input filename")?)
                 .with_extension("png");
 
-            input_files.push(InputFile { path, output_path })
+            let staging_path = PathBuf::from(staging_folder)
+                .join(path.file_name().context("input filename")?)
+                .with_extension("xyz.bin");
+
+            let mut file = fs.open(&path).context("opening input file")?;
+            let header =
+                las::raw::Header::read_from(&mut file).context("reading input file header")?;
+            let header: Header = header.into();
+            log::debug!(
+                "Reading file header: {:?} -> {:?}",
+                path.file_name(),
+                header
+            );
+
+            input_files.push(InputFile {
+                path,
+                output_path,
+                staging_path,
+                header,
+            })
         }
 
-        // now check if teir corresponding output files already exist, and if so, skip them
+        let mut mapping = mapping_from_headers(&input_files, padding);
+
+        // now check if their corresponding output files already exist, and if so, skip them
         let mut files_to_process: Vec<InputFileIndex> = Vec::with_capacity(input_files.len());
         for (i, input_file) in input_files.iter().enumerate() {
             if !fs.exists(&input_file.output_path) {
                 files_to_process.push(InputFileIndex(i));
+            } else {
+                // drop it from the mapping, so that we don't process it or its dependencies when not needed
+                mapping.remove(&InputFileIndex(i));
             }
         }
 
@@ -62,6 +101,7 @@ impl Plan {
         Ok(Self {
             input_files,
             files_to_process,
+            mapping,
         })
     }
 
@@ -75,5 +115,161 @@ impl Plan {
 
     pub fn files_to_process(&self) -> &[InputFileIndex] {
         &self.files_to_process
+    }
+
+    pub fn naive_planner(&self) -> Box<dyn Planner> {
+        Box::new(NaivePlanner::new(self.mapping.clone()))
+    }
+}
+
+/// Create a mapping of which files are dependent on which other files, based on their headers and a padding value.
+fn mapping_from_headers(
+    headers: &[InputFile],
+    padding: f64,
+) -> HashMap<InputFileIndex, HashSet<InputFileIndex>> {
+    let mut mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>> = HashMap::default();
+
+    // this is now O(n^2) but we expect n to be small, and it is simpler to implement than a spatial index
+    for (i, ih) in headers.iter().enumerate() {
+        let padded_bounds = ih.header.bounds.expand(padding);
+
+        let e = mapping.entry(InputFileIndex(i)).or_default();
+
+        for (j, jh) in headers.iter().enumerate() {
+            // skip self
+            if i == j {
+                continue;
+            }
+
+            // if overlap, there is a dependency (in both directions!)
+            if jh.header.bounds.overlaps(&padded_bounds) {
+                e.insert(InputFileIndex(j));
+            }
+        }
+    }
+    mapping
+}
+
+/// Represents the header of the input file.
+#[derive(Debug)]
+pub struct Header {
+    pub bounds: Rect,
+    #[allow(unused)]
+    pub n_points: u32,
+}
+
+impl From<las::raw::Header> for Header {
+    fn from(value: las::raw::Header) -> Self {
+        Self {
+            bounds: Rect::new(value.min_x, value.min_y, value.max_x, value.max_y),
+            n_points: value.number_of_point_records,
+        }
+    }
+}
+
+/// Represents an operation that needs to be performed in order to process the input files. This is
+/// generated by the `Planner` and executed by the `Performer`.
+#[derive(Debug)]
+pub enum Operation {
+    /// Load and extract a file into the file(s) specified.
+    /// The performer is required to respect the padding value (global),
+    /// and put all points that are within the padding area into the respective
+    /// destination files.
+    Extract {
+        from: InputFileIndex,
+        to: Vec<InputFileIndex>,
+    },
+    /// This indicates that the tile can be processed, eg. it has been filled with all points
+    /// from neighboring tiles (using `Extract` operations).
+    Process { tile: InputFileIndex },
+}
+
+pub trait Planner {
+    /// Get the next operation(s) to perform, if any. If it returns `None`, the processing is done.
+    fn next_operation(&mut self) -> Option<Vec<Operation>>;
+}
+
+pub struct NaivePlanner {
+    mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>>,
+}
+
+impl NaivePlanner {
+    fn new(mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>>) -> Self {
+        Self { mapping }
+    }
+}
+impl Planner for NaivePlanner {
+    fn next_operation(&mut self) -> Option<Vec<Operation>> {
+        // take the first key and process it
+        let Some(&i) = self.mapping.keys().next() else {
+            return None;
+        };
+
+        // construct operations to perform:
+        let mut ops = Vec::new();
+
+        // we need to extract from the tile itself to the tile
+        ops.push(Operation::Extract {
+            from: i,
+            to: vec![i],
+        });
+
+        // for each of our dependencies, extract from it to the tile itself (but not to any other
+        // tiles that also depend on it, which is what the `ExtractOncePlanner` does)
+        if let Some(deps) = self.mapping.remove(&i) {
+            for dep in deps {
+                ops.push(Operation::Extract {
+                    from: dep,
+                    to: vec![i],
+                });
+            }
+        }
+
+        // now we can process the tile i
+        ops.push(Operation::Process { tile: i });
+
+        Some(ops)
+    }
+}
+/// A simple rectangle struct to represent a rectangle in 2D space.
+#[derive(Debug, Clone)]
+pub struct Rect {
+    pub minx: f64,
+    pub miny: f64,
+    pub maxx: f64,
+    pub maxy: f64,
+}
+
+impl Rect {
+    pub fn new(minx: f64, miny: f64, maxx: f64, maxy: f64) -> Self {
+        Self {
+            minx,
+            miny,
+            maxx,
+            maxy,
+        }
+    }
+
+    /// Expand the rectangle by a given padding value in all directions.
+    pub fn expand(&self, padding: f64) -> Self {
+        Self {
+            minx: self.minx - padding,
+            miny: self.miny - padding,
+            maxx: self.maxx + padding,
+            maxy: self.maxy + padding,
+        }
+    }
+
+    /// Check if this rectangle overlaps with another rectangle.
+    pub fn overlaps(&self, other: &Rect) -> bool {
+        other.maxx > self.minx
+            && other.minx < self.maxx
+            && other.maxy > self.miny
+            && other.miny < self.maxy
+    }
+
+    /// Check if point is within the rectangle (excluding the boundary).
+    pub fn contains(&self, x: f64, y: f64) -> bool {
+        x > self.minx && x < self.maxx && y > self.miny && y < self.maxy
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -28,7 +28,7 @@ pub struct InputFile {
     pub header: Header,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct InputFileIndex(usize);
 
 impl Plan {
@@ -120,6 +120,9 @@ impl Plan {
 
     pub fn naive_planner(&self) -> Box<dyn Planner> {
         Box::new(NaivePlanner::new(self.mapping.clone()))
+    }
+    pub fn extract_once_planner(&self) -> Box<dyn Planner> {
+        Box::new(ExtractOncePlanner::new(self.mapping.clone()))
     }
 }
 
@@ -232,6 +235,90 @@ impl Planner for NaivePlanner {
         Some(ops)
     }
 }
+
+struct ExtractOncePlanner {
+    mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>>,
+}
+
+impl ExtractOncePlanner {
+    fn new(mut mapping: HashMap<InputFileIndex, HashSet<InputFileIndex>>) -> Self {
+        // for the logic we need every
+
+        for (key, value) in mapping.iter_mut() {
+            // also include the tile itself as a dependency, since we also need to extract it to
+            // itself in order to process it
+            value.insert(*key);
+        }
+        Self { mapping }
+    }
+}
+impl Planner for ExtractOncePlanner {
+    fn next_operation(&mut self) -> Option<Vec<Operation>> {
+        // take the file with lowest number of dependencies (or just the first one if there are multiple)
+        let Some((&i, deps)) = self.mapping.iter().min_by_key(|(_, deps)| deps.len()) else {
+            return None;
+        };
+
+        // // TODO: we could sort by fewest amount of total points to process as well...
+        // let n_points_total = mapping
+        //     .iter()
+        //     .map(|(i, deps)| {
+        //         headers[*i].n_points as u64
+        //             + deps
+        //                 .iter()
+        //                 .map(|i| headers[*i].n_points as u64)
+        //                 .sum::<u64>()
+        //     })
+        //     .collect::<Vec<_>>();
+        //
+        // println!("n_points_total: {n_points_total:?}");
+        //
+        // let Some((i, _)) = n_points_total
+        //     .iter()
+        //     .enumerate()
+        //     .min_by_key(|(_, count)| **count)
+        // else {
+        //     warn!("Could not find lowest n_points file");
+        //     break;
+        // };
+
+        // mapping is tile -> who should extract to _me_ for me to be able to process
+
+        // construct operations to perform:
+        let mut ops = Vec::new();
+
+        // clone to avoid borrowing issues
+        let deps = deps.clone();
+
+        // first extract all our dependencies to the ones that depend on them (including the tile itself)
+        for dep in deps {
+            let mut to = Vec::new();
+
+            // we need to extract from dep to everyone that depends on dep
+            for (j, tile) in self.mapping.iter_mut() {
+                // depends on dep? (also remove if exists)
+                if tile.remove(&dep) {
+                    // yes - we should extract into this one
+                    to.push(*j);
+                }
+            }
+
+            ops.push(Operation::Extract { from: dep, to });
+        }
+
+        assert!(
+            self.mapping.get(&i).unwrap().is_empty(),
+            "All dependencies should have been processed by now"
+        );
+
+        // now we can process the tile
+        self.mapping.remove(&i);
+        ops.push(Operation::Process { tile: i });
+
+        Some(ops)
+    }
+}
+
 /// A simple rectangle struct to represent a rectangle in 2D space.
 #[derive(Debug, Clone)]
 pub struct Rect {
@@ -272,5 +359,107 @@ impl Rect {
     /// Check if point is within the rectangle (excluding the boundary).
     pub fn contains(&self, x: f64, y: f64) -> bool {
         x > self.minx && x < self.maxx && y > self.miny && y < self.maxy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct OperationSummary {
+        extract_counts: HashMap<(InputFileIndex, InputFileIndex), u32>,
+        processed_tiles: HashMap<InputFileIndex, InputFileIndex>,
+    }
+
+    fn convert(
+        mapping: HashMap<usize, HashSet<usize>>,
+    ) -> HashMap<InputFileIndex, HashSet<InputFileIndex>> {
+        mapping
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    InputFileIndex(k),
+                    v.into_iter().map(InputFileIndex).collect(),
+                )
+            })
+            .collect()
+    }
+
+    fn summarize_operations(mut planner: impl Planner) -> OperationSummary {
+        // keep track of how many times we extract from each tile to each tile
+        let mut extract_counts: HashMap<(InputFileIndex, InputFileIndex), u32> = HashMap::default();
+        let mut processed_tiles: HashMap<InputFileIndex, InputFileIndex> = HashMap::default();
+        while let Some(next_ops) = planner.next_operation() {
+            for op in next_ops {
+                match op {
+                    Operation::Extract { from, to } => {
+                        for to_i in to {
+                            *extract_counts.entry((from, to_i)).or_default() += 1;
+                        }
+                    }
+                    Operation::Process { tile } => {
+                        processed_tiles.entry(tile).or_default().0 += 1;
+                    }
+                }
+            }
+        }
+
+        OperationSummary {
+            extract_counts,
+            processed_tiles,
+        }
+    }
+
+    #[test]
+    fn test_planning_single() {
+        let mapping = HashMap::from_iter([(0, HashSet::default())]);
+        let mapping = convert(mapping);
+
+        let ops1 = summarize_operations(NaivePlanner::new(mapping.clone()));
+        let ops2 = summarize_operations(ExtractOncePlanner::new(mapping));
+        assert_eq!(ops1, ops2);
+    }
+
+    #[test]
+    fn test_planning_1() {
+        let mapping = HashMap::from_iter([
+            (0, vec![1, 2].into_iter().collect()),
+            (1, vec![2].into_iter().collect()),
+            (2, HashSet::default()),
+        ]);
+        let mapping = convert(mapping);
+
+        let ops1 = summarize_operations(NaivePlanner::new(mapping.clone()));
+        let ops2 = summarize_operations(ExtractOncePlanner::new(mapping));
+        assert_eq!(ops1, ops2);
+    }
+
+    #[test]
+    fn test_planning_big() {
+        // {1: {0, 3, 5, 6, 2}, 6: {7, 5, 1, 8, 2}, 4: {9, 7, 3, 5, 11}, 0: {5, 3, 1}, 8: {11, 7, 5, 12, 6}, 12: {11, 7, 14, 8, 13}, 11: {7, 14, 10, 13, 9, 12, 8, 4}, 14: {11, 13, 12}, 10: {9, 11, 13}, 5: {0, 7, 3, 6, 2, 1, 8, 4}, 3: {0, 7, 5, 1, 4}, 9: {11, 7, 10, 4, 13}, 7: {11, 3, 6, 9, 5, 12, 8, 4}, 2: {6, 5, 1}, 13: {9, 11, 12, 10, 14}}
+
+        let mapping = HashMap::from_iter([
+            (0, vec![5, 3, 1].into_iter().collect()),
+            (1, vec![0, 3, 5, 6, 2].into_iter().collect()),
+            (2, vec![6, 5, 1].into_iter().collect()),
+            (3, vec![0, 7, 5, 1, 4].into_iter().collect()),
+            (4, vec![9, 7, 3, 5, 11].into_iter().collect()),
+            (5, vec![0, 7, 3, 6, 2, 1, 8, 4].into_iter().collect()),
+            (6, vec![7, 5, 1].into_iter().collect()),
+            (7, vec![11, 3, 6, 9, 5, 12, 8, 4].into_iter().collect()),
+            (8, vec![11, 7, 5, 12, 6].into_iter().collect()),
+            (9, vec![11, 7, 10, 4, 13].into_iter().collect()),
+            (10, vec![9, 11, 13].into_iter().collect()),
+            (11, vec![7, 14, 10, 13, 9, 12, 8, 4].into_iter().collect()),
+            (12, vec![11, 7, 14, 8, 13].into_iter().collect()),
+            (13, vec![9, 11, 12, 10, 14].into_iter().collect()),
+            (14, vec![11, 13, 12].into_iter().collect()),
+        ]);
+        let mapping = convert(mapping);
+
+        let ops1 = summarize_operations(NaivePlanner::new(mapping.clone()));
+        let ops2 = summarize_operations(ExtractOncePlanner::new(mapping));
+        assert_eq!(ops1, ops2);
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -153,8 +153,6 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
                     let mut pd = PointDataBuilder::new().for_header(reader.header()).build();
 
                     loop {
-                        // points.clear();
-                        // PD.clear?
                         let n = reader
                             .fill_points(LAZ_BUFFER_SIZE as u64, &mut pd)
                             .expect("could not read LAZ points");
@@ -164,7 +162,6 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
 
                         // for each dependency, we need to check all points against their boundary
                         // to know if they should be included in the output.
-
                         for &to_i in &to {
                             let to_file = plan.get_input_file(to_i);
                             let padded_bounds = to_file.header.bounds.expand(padding);

--- a/src/process.rs
+++ b/src/process.rs
@@ -35,9 +35,9 @@ use crate::util::Timing;
 use crate::util::read_lines_no_alloc;
 use crate::vegetation;
 
-// compute the number of elements we can buffer for 200MB of memory usage during LAZ -> XyzRecord conversion
+// compute the number of elements we can buffer for 50MB of memory usage during LAZ -> XyzRecord conversion
 const LAZ_BUFFER_SIZE: usize =
-    400 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
+    50 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
 
 /// Launches threads and coordinates the logic for processing multiple files in parallell.
 /// When it returns, all files have been processed and output files have been generated according to

--- a/src/process.rs
+++ b/src/process.rs
@@ -37,7 +37,7 @@ use crate::vegetation;
 
 // compute the number of elements we can buffer for 200MB of memory usage during LAZ -> XyzRecord conversion
 const LAZ_BUFFER_SIZE: usize =
-    200 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
+    400 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
 
 /// Launches threads and coordinates the logic for processing multiple files in parallell.
 /// When it returns, all files have been processed and output files have been generated according to
@@ -114,7 +114,6 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         handles.push(handle);
     }
 
-    // let mut planner = plan.naive_planner();
     let mut planner = plan.extract_once_planner();
 
     let mut writers: HashMap<InputFileIndex, XyzInternalWriter<_>> = HashMap::default();

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,10 +1,12 @@
 use anyhow::Context;
 use image::{GrayImage, Luma, Rgb, RgbImage, Rgba, RgbaImage};
 use itertools::izip;
-use las::{PointDataBuilder, Reader, raw::Header};
+use las::{PointDataBuilder, Reader};
 use log::debug;
 use log::info;
 use rand::prelude::*;
+use rustc_hash::FxHashMap as HashMap;
+use std::collections::hash_map::Entry;
 use std::error::Error;
 use std::io::BufRead;
 use std::io::Write;
@@ -24,7 +26,9 @@ use crate::io::xyz::XyzRecord;
 use crate::knolls;
 use crate::merge;
 use crate::plan::InputFileIndex;
+use crate::plan::Operation;
 use crate::plan::Plan;
+use crate::plan::Rect;
 use crate::render;
 use crate::util::Consumer;
 use crate::util::Timing;
@@ -51,12 +55,19 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         crate::shapefile::unzip_shapefiles(&fs, zip_files).unwrap();
     }
 
+    // TODO: this is hard-coded but should maybe be configurable?
+    let padding = 127.0;
+
+    let timing = Timing::start_now("create_plan");
     let plan = crate::plan::Plan::new_from_input_files(
         fs.clone(),
         &config.lazfolder,
         &config.batchoutfolder,
+        "temp_staging",
+        padding,
     )
     .context("creating plan")?;
+    drop(timing);
 
     let plan = Arc::new(plan);
 
@@ -87,10 +98,142 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         handles.push(handle);
     }
 
-    // we can now start sending the files to process to the threads
-    for laz in plan.files_to_process() {
-        // send only the ids of the files
-        tx.push(*laz);
+    let mut planner = plan.naive_planner();
+
+    // folder where we store temporary extracted files to process later
+    let staging_folder = Path::new("temp_staging");
+    fs.create_dir_all(staging_folder)
+        .context("Could not create staging folder")?;
+
+    let mut writers: HashMap<InputFileIndex, XyzInternalWriter<_>> = HashMap::default();
+
+    let options = las::ReaderOptions::default().with_laz_parallelism(if config.laz_parallel {
+        las::LazParallelism::Yes
+    } else {
+        las::LazParallelism::No
+    });
+    log::debug!("Using LAZ parallelism: {:?}", config.laz_parallel);
+
+    // prepare buffers needed for extraction of LAZ files based on the planned operations
+    let mut records = Vec::with_capacity(LAZ_BUFFER_SIZE);
+
+    let &Config {
+        zoff, thinfactor, ..
+    } = &*config;
+
+    let mut rng = rand::rng();
+    let randdist = rand::distr::Bernoulli::new(thinfactor).unwrap();
+
+    while let Some(ops) = planner.next_operation() {
+        for op in ops {
+            match op {
+                Operation::Extract { from, to } => {
+                    println!("Extracting from {from:?} to {to:?}");
+
+                    let laz_p = plan.get_input_file(from);
+
+                    let mut reader = Reader::with_options(
+                        fs.open(&laz_p.path).expect("Could not open file"),
+                        options,
+                    )
+                    .expect("Could not create reader");
+
+                    let mut pd = PointDataBuilder::new().for_header(reader.header()).build();
+
+                    loop {
+                        // points.clear();
+                        // PD.clear?
+                        let n = reader
+                            .fill_points(LAZ_BUFFER_SIZE as u64, &mut pd)
+                            .expect("could not read LAZ points");
+                        if n == 0 {
+                            break;
+                        }
+
+                        // for each dependency, we need to check all points against their boundary
+                        // to know if they should be included in the output.
+
+                        for &to_i in &to {
+                            let to_file = plan.get_input_file(to_i);
+                            let padded_bounds = to_file.header.bounds.expand(padding);
+
+                            let to_self = to_i == from;
+
+                            // convert all read points to records
+                            records.clear();
+                            for (
+                                pt_x,
+                                pt_y,
+                                pt_z,
+                                pt_classification,
+                                pt_number_of_returns,
+                                pt_return_number,
+                            ) in izip!(
+                                pd.x(),
+                                pd.y(),
+                                pd.z(),
+                                pd.classification(),
+                                pd.number_of_returns(),
+                                pd.return_number()
+                            ) {
+                                if (to_self || padded_bounds.contains(pt_x, pt_y))
+                                    && (thinfactor == 1.0 || rng.sample(randdist))
+                                {
+                                    records.push(crate::io::xyz::XyzRecord {
+                                        x: pt_x,
+                                        y: pt_y,
+                                        z: (pt_z + zoff) as f32,
+                                        classification: pt_classification,
+                                        number_of_returns: pt_number_of_returns,
+                                        return_number: pt_return_number,
+                                        ..Default::default()
+                                    });
+                                }
+                            }
+
+                            // get or create the writer for this file
+                            let writer = match writers.entry(to_i) {
+                                Entry::Occupied(e) => e.into_mut(),
+                                Entry::Vacant(e) => {
+                                    let outfile = &to_file.staging_path;
+                                    println!("Creating writer for tile {to_i:?} at {outfile:?}");
+                                    let writer = XyzInternalWriter::new(
+                                        fs.create(outfile)
+                                            .context("Could not create output file")?,
+                                    );
+                                    e.insert(writer)
+                                }
+                            };
+
+                            // write all at once
+                            writer
+                                .write_records(&records)
+                                .expect("Could not write records");
+
+                            // *point_counts.entry(to_i).or_default() += records.len() as u64;
+                        }
+                    }
+                }
+                Operation::Process { tile } => {
+                    println!("Processing tile {tile:?}");
+
+                    // make sure we close the file for this tile
+                    if let Some(mut w) = writers.remove(&tile) {
+                        w.finish().context("Could not finish writer")?;
+                    } else {
+                        log::error!(
+                            "Could not find writer for tile {tile:?} when trying to process it"
+                        );
+                        // TODO: error???
+                        continue;
+                    };
+
+                    // finally post output file for processing!
+                    // TODO: backpressure if the queue is full?
+                    tx.push(tile);
+                }
+            }
+        }
     }
 
     // we are done, close the producer and wait for all threads to exit
@@ -473,116 +616,37 @@ pub fn batch_process(
         savetempfiles,
         scalefactor,
         vege_bitmode,
-        zoff,
-        thinfactor,
         ..
     } = conf;
 
     let Config { batchoutfolder, .. } = conf;
 
-    let mut rng = rand::rng();
-    let randdist = rand::distr::Bernoulli::new(thinfactor).unwrap();
-
-    let options = las::ReaderOptions::default().with_laz_parallelism(if conf.laz_parallel {
-        las::LazParallelism::Yes
-    } else {
-        las::LazParallelism::No
-    });
-
     // take input files from queue until there are no more
     while let Some(laz_path) = rx.pop() {
         let file_to_process = plan.get_input_file(laz_path);
+
         let infile = file_to_process.path.as_path();
         let laz = infile.file_stem().unwrap().to_str().unwrap();
         let outfile = file_to_process.output_path.as_path();
 
         info!("{} -> {}", infile.display(), outfile.display());
 
-        let mut file = fs.open(infile).unwrap();
-        let header = Header::read_from(&mut file).unwrap();
-        let minx = header.min_x;
-        let miny = header.min_y;
-        let maxx = header.max_x;
-        let maxy = header.max_y;
+        let Rect {
+            minx,
+            miny,
+            maxx,
+            maxy,
+        } = file_to_process.header.bounds;
 
-        let minx2 = minx - 127.0;
-        let miny2 = miny - 127.0;
-        let maxx2 = maxx + 127.0;
-        let maxy2 = maxy + 127.0;
-
+        // we need to move the input points from the staging to our own temporary folder
         let tmp_filename = PathBuf::from(format!("temp{thread}.xyz.bin"));
-        debug!("Writing records to {:?}", tmp_filename);
-        let mut writer =
-            XyzInternalWriter::new(fs.create(&tmp_filename).expect("Could not create writer"));
-
-        // read points from all LAZ files that have an overlap with the main tile file
-        for laz_p in plan.input_files() {
-            let laz_p = &laz_p.path;
-            let mut file = fs.open(laz_p).unwrap();
-            let header = Header::read_from(&mut file).unwrap();
-            if header.max_x > minx2
-                && header.min_x < maxx2
-                && header.max_y > miny2
-                && header.min_y < maxy2
-            {
-                let mut reader =
-                    Reader::with_options(fs.open(laz_p).expect("Could not open file"), options)
-                        .expect("Could not create reader");
-
-                let mut records = Vec::with_capacity(LAZ_BUFFER_SIZE);
-                let mut pd = PointDataBuilder::new().for_header(reader.header()).build();
-
-                loop {
-                    let n = reader
-                        .fill_points(LAZ_BUFFER_SIZE as u64, &mut pd)
-                        .expect("could not read LAZ points");
-                    if n == 0 {
-                        break;
-                    }
-
-                    // convert all read points to records
-                    records.clear();
-                    for (
-                        pt_x,
-                        pt_y,
-                        pt_z,
-                        pt_classification,
-                        pt_number_of_returns,
-                        pt_return_number,
-                    ) in izip!(
-                        pd.x(),
-                        pd.y(),
-                        pd.z(),
-                        pd.classification(),
-                        pd.number_of_returns(),
-                        pd.return_number()
-                    ) {
-                        if pt_x > minx2
-                            && pt_x < maxx2
-                            && pt_y > miny2
-                            && pt_y < maxy2
-                            && (thinfactor == 1.0 || rng.sample(randdist))
-                        {
-                            records.push(crate::io::xyz::XyzRecord {
-                                x: pt_x,
-                                y: pt_y,
-                                z: (pt_z + zoff) as f32,
-                                classification: pt_classification,
-                                number_of_returns: pt_number_of_returns,
-                                return_number: pt_return_number,
-                                ..Default::default()
-                            });
-                        }
-                    }
-
-                    // write all at once
-                    writer
-                        .write_records(&records)
-                        .expect("Could not write records");
-                }
-            }
-        }
-        writer.finish().expect("Unable to finish writing");
+        debug!(
+            "Moving input file {} -> {}",
+            file_to_process.staging_path.display(),
+            tmp_filename.display()
+        );
+        fs.rename(&file_to_process.staging_path, &tmp_filename)
+            .expect("Could not move file to temporary folder");
 
         let tmpfolder = PathBuf::from(format!("temp{thread}"));
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -77,15 +77,18 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
 
     let plan = Arc::new(plan);
 
-    // insert them into the queue
-    let (tx, rx) = crate::util::make_bounded_queue::<InputFileIndex>(2);
-
     // make sure the output directory exists
     fs.create_dir_all(&config.batchoutfolder)
         .expect("Could not create output folder");
 
     // we only need to launch maximum as many threads as there are files to process
     let num_threads = config.processes.min(plan.files_to_process().len() as u64) as usize;
+
+    // Create a queue where we send the files that are ready to process to the worker threads.
+    // Bound it based on the number of threads so that we cannot have too many files converted
+    // waiting for processing at a time.
+    // TODO: make it configurable?
+    let (tx, rx) = crate::util::make_bounded_queue::<InputFileIndex>(num_threads / 2);
 
     // do the processing
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(num_threads);
@@ -96,11 +99,13 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         let has_zip = !zip_files.is_empty();
         let arc_plan = plan.clone();
 
-        let handle = thread::spawn(move || {
-            info!("Starting thread");
-            batch_process(&config, &fs, &format!("{}", i + 1), has_zip, arc_plan, rx);
-        });
-        thread::sleep(std::time::Duration::from_millis(100));
+        let handle = thread::Builder::new()
+            .name(format!("worker_{i}"))
+            .spawn(move || {
+                info!("Starting thread");
+                batch_process(&config, &fs, &format!("{}", i + 1), has_zip, arc_plan, rx);
+            })
+            .expect("Could not spawn thread");
         handles.push(handle);
     }
 
@@ -129,7 +134,7 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         for op in ops {
             match op {
                 Operation::Extract { from, to } => {
-                    println!("Extracting from {from:?} to {to:?}");
+                    log::trace!("Extracting from {from:?} to {to:?}");
 
                     let laz_p = plan.get_input_file(from);
 
@@ -197,7 +202,6 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
                                 Entry::Occupied(e) => e.into_mut(),
                                 Entry::Vacant(e) => {
                                     let outfile = &to_file.staging_path;
-                                    println!("Creating writer for tile {to_i:?} at {outfile:?}");
                                     let writer = XyzInternalWriter::new(
                                         fs.create(outfile)
                                             .context("Could not create output file")?,
@@ -210,27 +214,21 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
                             writer
                                 .write_records(&records)
                                 .expect("Could not write records");
-
-                            // *point_counts.entry(to_i).or_default() += records.len() as u64;
                         }
                     }
                 }
                 Operation::Process { tile } => {
-                    println!("Processing tile {tile:?}");
+                    log::trace!("Processing tile {tile:?}");
 
                     // make sure we close the file for this tile
                     if let Some(mut w) = writers.remove(&tile) {
                         w.finish().context("Could not finish writer")?;
                     } else {
-                        log::error!(
-                            "Could not find writer for tile {tile:?} when trying to process it"
-                        );
-                        // TODO: error???
-                        continue;
+                        anyhow::bail!("Internal error: missing writer for tile {tile:?}");
                     };
 
                     // finally post output file for processing!
-                    // TODO: backpressure if the queue is full?
+                    // This will block the main thread if the queue is full to provide backpressure.
                     tx.push(tile);
                 }
             }

--- a/src/process.rs
+++ b/src/process.rs
@@ -75,6 +75,11 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     .context("creating plan")?;
     drop(timing);
 
+    if plan.files_to_process().is_empty() {
+        info!("No files to process, exiting");
+        return Ok(());
+    }
+
     let plan = Arc::new(plan);
 
     // make sure the output directory exists
@@ -109,7 +114,8 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
         handles.push(handle);
     }
 
-    let mut planner = plan.naive_planner();
+    // let mut planner = plan.naive_planner();
+    let mut planner = plan.extract_once_planner();
 
     let mut writers: HashMap<InputFileIndex, XyzInternalWriter<_>> = HashMap::default();
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -35,9 +35,9 @@ use crate::util::Timing;
 use crate::util::read_lines_no_alloc;
 use crate::vegetation;
 
-// compute the number of elements we can buffer for 50MB of memory usage during LAZ -> XyzRecord conversion
+// compute the number of elements we can buffer for 200MB of memory usage during LAZ -> XyzRecord conversion
 const LAZ_BUFFER_SIZE: usize =
-    50 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
+    200 * 1024 * 1024 / (size_of::<las::Point>() + size_of::<XyzRecord>());
 
 /// Launches threads and coordinates the logic for processing multiple files in parallell.
 /// When it returns, all files have been processed and output files have been generated according to

--- a/src/process.rs
+++ b/src/process.rs
@@ -50,7 +50,8 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     // first unzip all zip files (if any) to a temporary folder, so that the threads can access the
     // shapefiles without having to worry about unzipping them in parallel
     let shapefiletmpdir = PathBuf::from("temp_shapefiles".to_string());
-    fs.create_dir_all(&shapefiletmpdir).unwrap();
+    fs.create_dir_all(&shapefiletmpdir)
+        .context("Could not create temporary folder for shapefiles")?;
     if !zip_files.is_empty() {
         crate::shapefile::unzip_shapefiles(&fs, zip_files).unwrap();
     }
@@ -58,12 +59,17 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     // TODO: this is hard-coded but should maybe be configurable?
     let padding = 127.0;
 
+    // folder where we store temporary extracted files to process later
+    let staging_folder = Path::new("temp_staging");
+    fs.create_dir_all(staging_folder)
+        .context("Could not create staging folder")?;
+
     let timing = Timing::start_now("create_plan");
     let plan = crate::plan::Plan::new_from_input_files(
         fs.clone(),
         &config.lazfolder,
         &config.batchoutfolder,
-        "temp_staging",
+        staging_folder,
         padding,
     )
     .context("creating plan")?;
@@ -72,7 +78,7 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     let plan = Arc::new(plan);
 
     // insert them into the queue
-    let (tx, rx) = crate::util::make_queue::<InputFileIndex>();
+    let (tx, rx) = crate::util::make_bounded_queue::<InputFileIndex>(2);
 
     // make sure the output directory exists
     fs.create_dir_all(&config.batchoutfolder)
@@ -99,11 +105,6 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     }
 
     let mut planner = plan.naive_planner();
-
-    // folder where we store temporary extracted files to process later
-    let staging_folder = Path::new("temp_staging");
-    fs.create_dir_all(staging_folder)
-        .context("Could not create staging folder")?;
 
     let mut writers: HashMap<InputFileIndex, XyzInternalWriter<_>> = HashMap::default();
 
@@ -243,7 +244,8 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     }
 
     // cleanup extracted shapefiles
-    fs.remove_dir_all(&shapefiletmpdir).unwrap();
+    fs.remove_dir_all(&shapefiletmpdir)
+        .context("Could not remove temporary shapefile folder")?;
     Ok(())
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -93,7 +93,7 @@ pub fn launch_threads<F: FileSystem + Send + Clone + 'static>(
     // Bound it based on the number of threads so that we cannot have too many files converted
     // waiting for processing at a time.
     // TODO: make it configurable?
-    let (tx, rx) = crate::util::make_bounded_queue::<InputFileIndex>(num_threads / 2);
+    let (tx, rx) = crate::util::make_bounded_queue::<InputFileIndex>((num_threads / 2).max(1));
 
     // do the processing
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(num_threads);

--- a/src/util.rs
+++ b/src/util.rs
@@ -155,14 +155,20 @@ pub fn write_object<W: std::io::Write, O: serde::Serialize>(
     Ok(())
 }
 
-/// A simple Single-Producer-Multiple-Consumer queue for passing work to processing threads.
-pub fn make_queue<T>() -> (Producer<T>, Consumer<T>) {
+/// A bounded Single-Producer-Multiple-Consumer queue.
+///
+/// [`Producer::push`] blocks when the queue contains `capacity` items, resuming once a consumer
+/// pops an item. This provides backpressure so the producer cannot outpace consumers.
+pub fn make_bounded_queue<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
+    assert!(capacity > 0, "queue capacity must be at least 1");
     let inner = Inner {
         inner: Mutex::new(InnerMut {
             queue: VecDeque::new(),
             has_closed: false,
         }),
+        capacity,
         var_has_items: Condvar::new(),
+        var_has_space: Condvar::new(),
     };
     let inner = Arc::new(inner);
 
@@ -175,7 +181,9 @@ pub fn make_queue<T>() -> (Producer<T>, Consumer<T>) {
 
 struct Inner<T> {
     inner: Mutex<InnerMut<T>>,
+    capacity: usize,
     var_has_items: Condvar,
+    var_has_space: Condvar,
 }
 
 struct InnerMut<T> {
@@ -188,11 +196,16 @@ pub struct Producer<T> {
 }
 
 impl<T> Producer<T> {
-    /// Pushes an item to the queue. Returns `Err` if the queue has been closed.
+    /// Pushes an item to the queue. Blocks if the queue is at capacity until space is available.
     pub fn push(&self, item: T) {
+        let start = Instant::now();
         let mut inner = self.inner.inner.lock().unwrap();
+        while inner.queue.len() >= self.inner.capacity {
+            inner = self.inner.var_has_space.wait(inner).unwrap();
+        }
         inner.queue.push_back(item);
         self.inner.var_has_items.notify_one();
+        log::debug!("Waited {:.2?} to push item to queue", start.elapsed());
     }
 }
 
@@ -212,9 +225,12 @@ pub struct Consumer<T> {
 impl<T> Consumer<T> {
     /// Pops an item from the queue. Returns `None` if the queue has been closed and is empty.
     pub fn pop(&self) -> Option<T> {
+        let start = Instant::now();
         let mut inner = self.inner.inner.lock().unwrap();
         loop {
             if let Some(item) = inner.queue.pop_front() {
+                self.inner.var_has_space.notify_one();
+                log::debug!("Waited {:.2?} to pop item from queue", start.elapsed());
                 return Some(item);
             }
             if inner.has_closed {
@@ -233,6 +249,30 @@ mod tests {
     #[test]
     fn test_queue() {
         let (producer, consumer) = make_queue();
+
+        let producer_thread = thread::spawn(move || {
+            for i in 0..10 {
+                producer.push(i);
+            }
+        });
+
+        let consumer_thread = thread::spawn(move || {
+            let mut items = Vec::new();
+            while let Some(item) = consumer.pop() {
+                items.push(item);
+            }
+            items
+        });
+
+        producer_thread.join().unwrap();
+        let items = consumer_thread.join().unwrap();
+        assert_eq!(items, (0..10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_bounded_queue_backpressure() {
+        // Queue of capacity 2: producer should block until consumers drain items.
+        let (producer, consumer) = make_bounded_queue(2);
 
         let producer_thread = thread::spawn(move || {
             for i in 0..10 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_queue() {
-        let (producer, consumer) = make_queue();
+        let (producer, consumer) = make_bounded_queue(usize::MAX);
 
         let producer_thread = thread::spawn(move || {
             for i in 0..10 {
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_multiple_consumer() {
-        let (producer, consumer) = make_queue();
+        let (producer, consumer) = make_bounded_queue(usize::MAX);
 
         let producer_thread = thread::spawn(move || {
             for i in 0..10 {


### PR DESCRIPTION
Note: **This is a WIP PR**

The main idea is that we refactor the batch processing logic so that the main thread is responsible for reading/decompressing LAS/LAZ files into a staging area, and that there is a planning step that knows which input file that depends on which output file. I added a Naive planner that mirrors the current logic, and then there is a smarter one that only reads each LAS/LAZ file _once_ (since at least for me the LAZ reading shows up as a big part of the execution time). The files containing the lidar points for processing reside in a new `temp_staging` folder and are later moved into each threads tmpX folder when being processed. Thus there is a nice tradeoff between processing time and disk usage.

Im hoping that this  can bring some speedups for batch jobs, while also providing the flexibility to trade processing time for disk space / memory (if using the in-memory FS!).

Please test it out and provide some feedback! :rocket: