### PR TITLE
Add option to draw slope line indicators on depressions + add option to customize depression contours color

### DIFF
--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -237,6 +237,11 @@ output_dxf=1
 # configured to be used during LAZ file decompression. Defaults to 0 if not configured.
 parallel_laz_decompression=1
 
+# Set to 1 to add slope lines on depressions
+draw_slopelines = 0
+# Set RGB color of depressions when drawn (default purple). Same color as contours would be 166,85,43
+depressions_color = 200,0,200
+
 #------------------------------------------------------#
 #              EXPERIMENTAL OPTIONS                    #
 #            (No stability guarantees)                 #

--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -237,8 +237,8 @@ output_dxf=1
 # configured to be used during LAZ file decompression. Defaults to 0 if not configured.
 parallel_laz_decompression=1
 
-# Set to 1 to add slope lines on depressions
-draw_slopelines = 0
+# Set to 1 to add slope lines on depressions, and draw small depressions with specific symbol. This should be used to be ISOM2017 compliant.
+decorate_depressions = 0
 # Set RGB color of depressions when drawn (default purple). Same color as contours would be 166,85,43
 depressions_color = 200,0,200
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ pub struct Config {
     pub remove_touching_contours: bool,
 
     pub depressions_color: (u8, u8, u8),
-    pub draw_slopelines: bool,
+    pub decorate_depressions: bool,
 }
 
 pub struct Zone {
@@ -355,7 +355,7 @@ impl Config {
                 split.next().unwrap_or("0").parse::<u8>().unwrap_or(0),
             )
         };
-        let draw_slopelines = gs.get("draw_slopelines").unwrap_or("0") == "1";
+        let decorate_depressions = gs.get("decorate_depressions").unwrap_or("0") == "1";
 
         let batch = gs.get("batch").unwrap() == "1";
         if batch && processes == 0 {
@@ -445,7 +445,7 @@ impl Config {
             label_depressions,
             remove_touching_contours,
             depressions_color,
-            draw_slopelines,
+            decorate_depressions,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,9 @@ pub struct Config {
     pub minimumgap: u32,
     pub label_depressions: bool,
     pub remove_touching_contours: bool,
+
+    pub depressions_color: (u8, u8, u8),
+    pub draw_slopelines: bool,
 }
 
 pub struct Zone {
@@ -340,6 +343,20 @@ impl Config {
         let label_depressions: bool = gs.get("label_formlines_depressions").unwrap_or("0") == "1";
         let remove_touching_contours: bool =
             gs.get("remove_touching_contours").unwrap_or("0") == "1";
+
+        let depressions_color: (u8, u8, u8) = {
+            let mut split = gs
+                .get("depressions_color")
+                .unwrap_or("200,0,200")
+                .split(',');
+            (
+                split.next().unwrap_or("0").parse::<u8>().unwrap_or(0),
+                split.next().unwrap_or("0").parse::<u8>().unwrap_or(0),
+                split.next().unwrap_or("0").parse::<u8>().unwrap_or(0),
+            )
+        };
+        let draw_slopelines = gs.get("draw_slopelines").unwrap_or("0") == "1";
+
         let batch = gs.get("batch").unwrap() == "1";
         if batch && processes == 0 {
             return Err(
@@ -427,6 +444,8 @@ impl Config {
             minimumgap,
             label_depressions,
             remove_touching_contours,
+            depressions_color,
+            draw_slopelines,
         })
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -114,6 +114,11 @@ impl<P, C> Polylines<P, C> {
         self.classification.push(class);
     }
 
+    pub fn pop(&mut self) {
+        self.polylines.pop();
+        self.classification.pop();
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&Vec<P>, &C)> {
         self.polylines.iter().zip(self.classification.iter())
     }
@@ -340,6 +345,7 @@ pub enum Classification {
     /// at least one slope line"), not a symbol of its own, so it carries contour weight
     /// and maps to 101 downstream. Generated in merge, alongside the ring it belongs to.
     SlopeLine,
+    SmallDepression,
 }
 
 impl Classification {
@@ -373,6 +379,7 @@ impl Classification {
             Self::Cliff4 => "cliff4",
 
             Self::SlopeLine => "slope_line",
+            Self::SmallDepression => "small_depression",
         }
     }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -334,6 +334,12 @@ pub enum Classification {
     Cliff2,
     Cliff3,
     Cliff4,
+
+    /// The tick drawn inside a depression contour so it reads as a depression rather
+    /// than a knoll. ISOM 2017-2 makes it part of symbol 101 ("a depression has to have
+    /// at least one slope line"), not a symbol of its own, so it carries contour weight
+    /// and maps to 101 downstream. Generated in merge, alongside the ring it belongs to.
+    SlopeLine,
 }
 
 impl Classification {
@@ -365,6 +371,8 @@ impl Classification {
             Self::Cliff2 => "cliff2",
             Self::Cliff3 => "cliff3",
             Self::Cliff4 => "cliff4",
+
+            Self::SlopeLine => "slope_line",
         }
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -388,7 +388,7 @@ fn decorate_depression(
     let (w, hgt) = (xmax - xmin, ymax - ymin);
     if w.max(hgt) < MIN_LENGTH_M || w.min(hgt) < MIN_WIDTH_M {
         // draw a small depression
-        let center = ((xmax + xmin) / 2.0, (ymax + ymin) / 2.0);
+        let center = ((xmax + xmin) / 2.0, (ymax + ymin + LENGTH_M) / 2.0);
         let steps = 8;
         let mut points = Vec::with_capacity(steps);
         let radius = LENGTH_M;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1071,3 +1071,102 @@ pub fn smoothjoin(
     info!("Done");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::slope_line;
+
+    /// A closed ring approximating a circle of the given ground radius, in metres.
+    fn ring(radius: f64) -> (Vec<f64>, Vec<f64>) {
+        let (mut x, mut y) = (Vec::new(), Vec::new());
+        for i in 0..=24 {
+            let a = i as f64 / 24.0 * std::f64::consts::TAU;
+            x.push(100.0 + radius * a.cos());
+            y.push(200.0 + radius * a.sin());
+        }
+        (x, y)
+    }
+
+    #[test]
+    fn the_tick_points_into_the_depression() {
+        let (x, y) = ring(20.0);
+        let tick = slope_line(&x, &y, 12.5).expect("a 40 m depression carries a slope line");
+        let (start, end) = (&tick[0], &tick[1]);
+        let d_start = ((start.x - 100.0).powi(2) + (start.y - 200.0).powi(2)).sqrt();
+        let d_end = ((end.x - 100.0).powi(2) + (end.y - 200.0).powi(2)).sqrt();
+        assert!(
+            d_end < d_start,
+            "tick must point inward: {d_start} -> {d_end}"
+        );
+        assert_eq!(start.z, 12.5);
+    }
+
+    #[test]
+    fn the_tick_is_the_isom_length() {
+        let (x, y) = ring(20.0);
+        let tick = slope_line(&x, &y, 0.0).unwrap();
+        // 0.4 OM -> 0.6 mm at 1:10,000 -> 6 m on the ground.
+        let len = ((tick[1].x - tick[0].x).powi(2) + (tick[1].y - tick[0].y).powi(2)).sqrt();
+        assert!((len - 6.0).abs() < 1e-9, "{len}");
+    }
+
+    #[test]
+    fn a_ring_below_the_isom_minimum_gets_no_tick() {
+        // Under 16.5 x 10.5 m a contour depression may not be drawn at all.
+        let (x, y) = ring(4.0);
+        assert!(slope_line(&x, &y, 0.0).is_none());
+    }
+
+    #[test]
+    fn winding_does_not_flip_the_tick_outward() {
+        let (x, y) = ring(20.0);
+        let (rx, ry): (Vec<f64>, Vec<f64>) = (
+            x.iter().rev().copied().collect(),
+            y.iter().rev().copied().collect(),
+        );
+        let tick = slope_line(&rx, &ry, 0.0).unwrap();
+        let d_start = ((tick[0].x - 100.0).powi(2) + (tick[0].y - 200.0).powi(2)).sqrt();
+        let d_end = ((tick[1].x - 100.0).powi(2) + (tick[1].y - 200.0).powi(2)).sqrt();
+        assert!(d_end < d_start, "reversed winding must still point inward");
+    }
+
+    /// A crescent: its centroid falls OUTSIDE the ring, which is what sent the tick to
+    /// the wrong side on Nyrup Hegn. Shaped like a C opening to the right.
+    fn crescent() -> (Vec<f64>, Vec<f64>) {
+        let (mut x, mut y) = (Vec::new(), Vec::new());
+        for i in 0..=40 {
+            // outer arc, 270 degrees
+            let a = i as f64 / 40.0 * (1.5 * std::f64::consts::PI) + 0.25 * std::f64::consts::PI;
+            x.push(100.0 + 30.0 * a.cos());
+            y.push(200.0 + 30.0 * a.sin());
+        }
+        for i in (0..=40).rev() {
+            // inner arc back
+            let a = i as f64 / 40.0 * (1.5 * std::f64::consts::PI) + 0.25 * std::f64::consts::PI;
+            x.push(100.0 + 20.0 * a.cos());
+            y.push(200.0 + 20.0 * a.sin());
+        }
+        x.push(x[0]);
+        y.push(y[0]);
+        (x, y)
+    }
+
+    #[test]
+    fn a_crescent_ring_still_gets_an_inward_tick() {
+        let (x, y) = crescent();
+        let tick = super::slope_line(&x, &y, 0.0).expect("crescent is big enough");
+        assert!(
+            super::point_in_ring(&x, &y, tick[1].x, tick[1].y),
+            "tick end must be inside the ring, not outside it"
+        );
+    }
+
+    #[test]
+    fn the_tick_keeps_clear_of_the_contour() {
+        let (x, y) = crescent();
+        let tick = super::slope_line(&x, &y, 0.0).unwrap();
+        // The crescent is 10 m wide, so a 6 m tick placed well has room to spare; the
+        // failure this guards is a tick laid along or across the ring itself.
+        assert!(super::distance_to_ring(&x, &y, tick[1].x, tick[1].y) > 0.5);
+    }
+}

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -362,7 +362,11 @@ pub fn bindxfmerge(fs: &impl FileSystem, config: &Config) -> anyhow::Result<()> 
 /// sits deepest inside — furthest from any part of the ring. That keeps the tick clear of
 /// the contour instead of crossing it where the depression pinches, which is where a
 /// fixed position lands on an elongated ring.
-fn slope_line(el_x: &[f64], el_y: &[f64], h: f64) -> Option<Vec<Point3>> {
+fn decorate_depression(
+    el_x: &[f64],
+    el_y: &[f64],
+    h: f64,
+) -> Option<(Vec<Point3>, Classification)> {
     const LENGTH_M: f64 = 6.0;
     const MIN_WIDTH_M: f64 = 10.5;
     const MIN_LENGTH_M: f64 = 16.5;
@@ -370,7 +374,7 @@ fn slope_line(el_x: &[f64], el_y: &[f64], h: f64) -> Option<Vec<Point3>> {
     const CANDIDATES: usize = 12;
 
     let n = el_x.len();
-    if n < 4 {
+    if n < 2 {
         return None;
     }
     let (mut xmin, mut xmax) = (f64::MAX, f64::MIN);
@@ -383,7 +387,19 @@ fn slope_line(el_x: &[f64], el_y: &[f64], h: f64) -> Option<Vec<Point3>> {
     }
     let (w, hgt) = (xmax - xmin, ymax - ymin);
     if w.max(hgt) < MIN_LENGTH_M || w.min(hgt) < MIN_WIDTH_M {
-        return None;
+        // draw a small depression
+        let center = ((xmax + xmin) / 2.0, (ymax + ymin) / 2.0);
+        let steps = 8;
+        let mut points = Vec::with_capacity(steps);
+        let radius = LENGTH_M;
+        for i in 0..steps {
+            // Angle from 0 to PI (semi-circle)
+            let angle = std::f64::consts::PI * ((i as f64) / ((steps - 1) as f64) + 1.0);
+            let x = center.0 + radius * angle.cos();
+            let y = center.1 + radius * angle.sin();
+            points.push(Point3::new(x, y, h));
+        }
+        return Some((points, Classification::SmallDepression));
     }
 
     let mut best: Option<(f64, [f64; 4])> = None;
@@ -408,7 +424,10 @@ fn slope_line(el_x: &[f64], el_y: &[f64], h: f64) -> Option<Vec<Point3>> {
         }
     }
     let (_, [sx, sy, ex, ey]) = best?;
-    Some(vec![Point3::new(sx, sy, h), Point3::new(ex, ey, h)])
+    Some((
+        vec![Point3::new(sx, sy, h), Point3::new(ex, ey, h)],
+        Classification::SlopeLine,
+    ))
 }
 
 /// Ray casting against the closed ring. Exact for concave shapes, which is the point.
@@ -1039,15 +1058,16 @@ pub fn smoothjoin(
                 // — the reader cannot tell which way the ground goes. KP classified
                 // depressions but never drew the tick, and the vector output then folded
                 // `depression` into plain 101, so the distinction was lost for good.
-                //
-                // TODO: If slope_line returns None, the depression is too small to draw
-                // a slope line, we should then not draw the deppression contour and put a
-                // small depression symbol instead.
-                if config.draw_slopelines
+                // if the return element happens to be a small depression, lets remove the
+                // original countour
+                if config.decorate_depressions
                     && layer.is_depression()
-                    && let Some(tick) = slope_line(&el_x[l], &el_y[l], h)
+                    && let Some((form, class)) = decorate_depression(&el_x[l], &el_y[l], h)
                 {
-                    out2_lines.push(tick, (Classification::SlopeLine, h));
+                    if class == Classification::SmallDepression {
+                        out2_lines.pop();
+                    }
+                    out2_lines.push(form, (class, h));
                 }
             } // -- if not dotkoll
         }
@@ -1074,9 +1094,9 @@ pub fn smoothjoin(
 
 #[cfg(test)]
 mod tests {
-    use super::slope_line;
-
-    /// A closed ring approximating a circle of the given ground radius, in metres.
+    use super::Classification;
+    use super::decorate_depression;
+    // A closed ring approximating a circle of the given ground radius, in metres.
     fn ring(radius: f64) -> (Vec<f64>, Vec<f64>) {
         let (mut x, mut y) = (Vec::new(), Vec::new());
         for i in 0..=24 {
@@ -1090,7 +1110,9 @@ mod tests {
     #[test]
     fn the_tick_points_into_the_depression() {
         let (x, y) = ring(20.0);
-        let tick = slope_line(&x, &y, 12.5).expect("a 40 m depression carries a slope line");
+        let (tick, class) =
+            decorate_depression(&x, &y, 12.5).expect("a 40 m depression carries a slope line");
+        assert!(class == Classification::SlopeLine);
         let (start, end) = (&tick[0], &tick[1]);
         let d_start = ((start.x - 100.0).powi(2) + (start.y - 200.0).powi(2)).sqrt();
         let d_end = ((end.x - 100.0).powi(2) + (end.y - 200.0).powi(2)).sqrt();
@@ -1104,7 +1126,7 @@ mod tests {
     #[test]
     fn the_tick_is_the_isom_length() {
         let (x, y) = ring(20.0);
-        let tick = slope_line(&x, &y, 0.0).unwrap();
+        let (tick, _class) = decorate_depression(&x, &y, 0.0).unwrap();
         // 0.4 OM -> 0.6 mm at 1:10,000 -> 6 m on the ground.
         let len = ((tick[1].x - tick[0].x).powi(2) + (tick[1].y - tick[0].y).powi(2)).sqrt();
         assert!((len - 6.0).abs() < 1e-9, "{len}");
@@ -1114,7 +1136,8 @@ mod tests {
     fn a_ring_below_the_isom_minimum_gets_no_tick() {
         // Under 16.5 x 10.5 m a contour depression may not be drawn at all.
         let (x, y) = ring(4.0);
-        assert!(slope_line(&x, &y, 0.0).is_none());
+        let (_tick, class) = decorate_depression(&x, &y, 0.0).unwrap();
+        assert!(class == Classification::SmallDepression);
     }
 
     #[test]
@@ -1124,7 +1147,7 @@ mod tests {
             x.iter().rev().copied().collect(),
             y.iter().rev().copied().collect(),
         );
-        let tick = slope_line(&rx, &ry, 0.0).unwrap();
+        let (tick, _class) = decorate_depression(&rx, &ry, 0.0).unwrap();
         let d_start = ((tick[0].x - 100.0).powi(2) + (tick[0].y - 200.0).powi(2)).sqrt();
         let d_end = ((tick[1].x - 100.0).powi(2) + (tick[1].y - 200.0).powi(2)).sqrt();
         assert!(d_end < d_start, "reversed winding must still point inward");
@@ -1154,7 +1177,7 @@ mod tests {
     #[test]
     fn a_crescent_ring_still_gets_an_inward_tick() {
         let (x, y) = crescent();
-        let tick = super::slope_line(&x, &y, 0.0).expect("crescent is big enough");
+        let (tick, _class) = decorate_depression(&x, &y, 0.0).expect("crescent is big enough");
         assert!(
             super::point_in_ring(&x, &y, tick[1].x, tick[1].y),
             "tick end must be inside the ring, not outside it"
@@ -1164,7 +1187,7 @@ mod tests {
     #[test]
     fn the_tick_keeps_clear_of_the_contour() {
         let (x, y) = crescent();
-        let tick = super::slope_line(&x, &y, 0.0).unwrap();
+        let (tick, _class) = decorate_depression(&x, &y, 0.0).unwrap();
         // The crescent is 10 m wide, so a 6 m tick placed well has room to spare; the
         // failure this guards is a tick laid along or across the ring itself.
         assert!(super::distance_to_ring(&x, &y, tick[1].x, tick[1].y) > 0.5);

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -343,6 +343,112 @@ pub fn bindxfmerge(fs: &impl FileSystem, config: &Config) -> anyhow::Result<()> 
     Ok(())
 }
 
+/// The slope-line tick for a depression ring, or `None` when the ring is too small to
+/// carry the symbol.
+///
+/// ISOM 2017-2 (symbol 101) requires at least one slope line on a depression, drawn
+/// perpendicular to the contour and pointing downslope — i.e. into the ring. Its length
+/// is 0.4 OM on the 1:15,000 original, 0.6 mm at the 1:10,000 we render, which is 6 m on
+/// the ground; coordinates here are ground metres. A depression below ISOM's minimum
+/// size (1.1 x 0.7 OM -> 1.65 x 1.05 mm -> 16.5 x 10.5 m) is not drawable as a contour
+/// depression at all — those are the small-depression symbol's job — so it gets no tick.
+///
+/// Direction is decided by testing whether the tick's far end lands INSIDE the ring, not
+/// by aiming at the ring's centroid: a depression ring is often a long crescent, and a
+/// crescent's centroid lies outside it, so the centroid test pointed the tick out of the
+/// depression — the "wrong side" seen on Nyrup Hegn.
+///
+/// Placement then picks, among candidates spread around the ring, the one whose tick end
+/// sits deepest inside — furthest from any part of the ring. That keeps the tick clear of
+/// the contour instead of crossing it where the depression pinches, which is where a
+/// fixed position lands on an elongated ring.
+fn slope_line(el_x: &[f64], el_y: &[f64], h: f64) -> Option<Vec<Point3>> {
+    const LENGTH_M: f64 = 6.0;
+    const MIN_WIDTH_M: f64 = 10.5;
+    const MIN_LENGTH_M: f64 = 16.5;
+    /// Positions tried around the ring; the best-clearance one wins.
+    const CANDIDATES: usize = 12;
+
+    let n = el_x.len();
+    if n < 4 {
+        return None;
+    }
+    let (mut xmin, mut xmax) = (f64::MAX, f64::MIN);
+    let (mut ymin, mut ymax) = (f64::MAX, f64::MIN);
+    for (&x, &y) in el_x.iter().zip(el_y.iter()) {
+        xmin = xmin.min(x);
+        xmax = xmax.max(x);
+        ymin = ymin.min(y);
+        ymax = ymax.max(y);
+    }
+    let (w, hgt) = (xmax - xmin, ymax - ymin);
+    if w.max(hgt) < MIN_LENGTH_M || w.min(hgt) < MIN_WIDTH_M {
+        return None;
+    }
+
+    let mut best: Option<(f64, [f64; 4])> = None;
+    for k in 0..CANDIDATES {
+        let i = k * n / CANDIDATES;
+        let (prev, next) = ((i + n - 1) % n, (i + 1) % n);
+        let (tx, ty) = (el_x[next] - el_x[prev], el_y[next] - el_y[prev]);
+        let len = (tx * tx + ty * ty).sqrt();
+        if len == 0.0 {
+            continue;
+        }
+        // Both perpendiculars; keep whichever ends up inside the ring.
+        for (nx, ny) in [(-ty / len, tx / len), (ty / len, -tx / len)] {
+            let (ex, ey) = (el_x[i] + nx * LENGTH_M, el_y[i] + ny * LENGTH_M);
+            if !point_in_ring(el_x, el_y, ex, ey) {
+                continue;
+            }
+            let clearance = distance_to_ring(el_x, el_y, ex, ey);
+            if best.is_none_or(|(b, _)| clearance > b) {
+                best = Some((clearance, [el_x[i], el_y[i], ex, ey]));
+            }
+        }
+    }
+    let (_, [sx, sy, ex, ey]) = best?;
+    Some(vec![Point3::new(sx, sy, h), Point3::new(ex, ey, h)])
+}
+
+/// Ray casting against the closed ring. Exact for concave shapes, which is the point.
+fn point_in_ring(el_x: &[f64], el_y: &[f64], px: f64, py: f64) -> bool {
+    let n = el_x.len();
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        if (el_y[i] > py) != (el_y[j] > py) {
+            let t = (py - el_y[i]) / (el_y[j] - el_y[i]);
+            if px < el_x[i] + t * (el_x[j] - el_x[i]) {
+                inside = !inside;
+            }
+        }
+        j = i;
+    }
+    inside
+}
+
+/// Shortest distance from a point to the ring's segments — the tick's clearance.
+fn distance_to_ring(el_x: &[f64], el_y: &[f64], px: f64, py: f64) -> f64 {
+    let n = el_x.len();
+    let mut best = f64::MAX;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let (ax, ay) = (el_x[i], el_y[i]);
+        let (bx, by) = (el_x[j], el_y[j]);
+        let (dx, dy) = (bx - ax, by - ay);
+        let l2 = dx * dx + dy * dy;
+        let t = if l2 == 0.0 {
+            0.0
+        } else {
+            (((px - ax) * dx + (py - ay) * dy) / l2).clamp(0.0, 1.0)
+        };
+        let (cx, cy) = (ax + t * dx, ay + t * dy);
+        best = best.min(((px - cx).powi(2) + (py - cy).powi(2)).sqrt());
+    }
+    best
+}
+
 pub fn smoothjoin(
     fs: &impl FileSystem,
     config: &Config,
@@ -927,6 +1033,18 @@ pub fn smoothjoin(
                         .collect(),
                     (layer, h),
                 );
+
+                // ISOM 2017-2, symbol 101: "a depression has to have at least one slope
+                // line". Without one a depression ring is indistinguishable from a knoll
+                // — the reader cannot tell which way the ground goes. KP classified
+                // depressions but never drew the tick, and the vector output then folded
+                // `depression` into plain 101, so the distinction was lost for good.
+                if config.draw_slopelines
+                    && layer.is_depression()
+                    && let Some(tick) = slope_line(&el_x[l], &el_y[l], h)
+                {
+                    out2_lines.push(tick, (Classification::SlopeLine, h));
+                }
             } // -- if not dotkoll
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -463,9 +463,9 @@ fn distance_to_ring(el_x: &[f64], el_y: &[f64], px: f64, py: f64) -> f64 {
             (((px - ax) * dx + (py - ay) * dy) / l2).clamp(0.0, 1.0)
         };
         let (cx, cy) = (ax + t * dx, ay + t * dy);
-        best = best.min(((px - cx).powi(2) + (py - cy).powi(2)).sqrt());
+        best = best.min((px - cx).powi(2) + (py - cy).powi(2));
     }
-    best
+    best.sqrt()
 }
 
 pub fn smoothjoin(

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1039,6 +1039,10 @@ pub fn smoothjoin(
                 // — the reader cannot tell which way the ground goes. KP classified
                 // depressions but never drew the tick, and the vector output then folded
                 // `depression` into plain 101, so the distinction was lost for good.
+                //
+                // TODO: If slope_line returns None, the depression is too small to draw
+                // a slope line, we should then not draw the deppression contour and put a
+                // small depression symbol instead.
                 if config.draw_slopelines
                     && layer.is_depression()
                     && let Some(tick) = slope_line(&el_x[l], &el_y[l], h)

--- a/src/render.rs
+++ b/src/render.rs
@@ -344,6 +344,30 @@ fn draw_cliffs(
     Ok(())
 }
 
+/// Is a closed form line ring smaller than ISOM allows the symbol to be drawn?
+///
+/// ISOM 2017-2 sets the minimum closed form line (knoll or depression) at 1.1 OM on the
+/// 1:15,000 original, which is 1.65 mm at the 1:10,000 we render — 16.5 m on the ground.
+/// Measured on the ring's longer bounding-box side, so an elongated ring is judged by
+/// its length: this drops specks, not real knolls.
+///
+/// `x`/`y` arrive in render pixels (600 dpi, 1:10,000, divided by `scalefactor`), so the
+/// inverse of that transform converts back to metres — the same one `formiline_points`
+/// uses when it writes ground coordinates.
+fn closed_ring_below_isom_minimum(x: &[f64], y: &[f64], scalefactor: f64) -> bool {
+    const MIN_GROUND_M: f64 = 16.5;
+    let (mut xmin, mut xmax) = (f64::MAX, f64::MIN);
+    let (mut ymin, mut ymax) = (f64::MAX, f64::MIN);
+    for (&px, &py) in x.iter().zip(y.iter()) {
+        xmin = xmin.min(px);
+        xmax = xmax.max(px);
+        ymin = ymin.min(py);
+        ymax = ymax.max(py);
+    }
+    let to_metres = 254.0 / 600.0 * scalefactor;
+    (xmax - xmin).max(ymax - ymin) * to_metres < MIN_GROUND_M
+}
+
 pub fn draw_curves(
     fs: &impl FileSystem,
     config: &Config,
@@ -510,10 +534,17 @@ pub fn draw_curves(
         let x = line.iter().map(|p| p.x).collect::<Vec<_>>();
         let y = line.iter().map(|p| p.y).collect::<Vec<_>>();
 
-        let color = if layer.is_contour() {
+        // The slope line is part of symbol 101, so it carries depression contour color
+        // weight — it just belongs to a depression, hence the nodepressions gate below.
+        let color = if layer.is_contour() && layer != Classification::SlopeLine {
             Rgba([166, 85, 43, 255]) // brown
         } else {
-            Rgba([200, 0, 200, 255]) // purple
+            Rgba([
+                config.depressions_color.0,
+                config.depressions_color.1,
+                config.depressions_color.2,
+                255,
+            ]) // Default purple
         };
 
         if !nodepressions || layer.is_contour() {
@@ -626,12 +657,30 @@ pub fn draw_curves(
                     }
                 }
                 // Let's not break small form line rings
+                //
+                // ...but only down to the size ISOM allows one to be drawn at. A closed
+                // form line is legitimate for a knoll or depression (ISOM 2017-2 symbol
+                // 103) and dashing it would not read as a ring, which is why this rule
+                // promotes a qualifying small ring to a solid loop. The rule had no
+                // minimum size though, so a ring of a handful of vertices was promoted
+                // exactly like a real knoll. On flat hummocky ground with form lines at
+                // a 1.25 m interval that is most of the rings on the map, and the result
+                // is a render covered in closed loops that carry no information and are
+                // below the size the symbol may legally be drawn at anyway.
+                //
+                // Rings under the ISOM minimum are therefore dropped rather than filled
+                // in. Both the raster and the form line vector output are gated on
+                // help2/smallringtest below, so the two stay consistent.
                 smallringtest = false;
                 if x.first() == x.last() && y.first() == y.last() && x.len() < 122 {
                     for i in 1..x.len() {
                         if help2[i] {
                             smallringtest = true
                         }
+                    }
+                    if smallringtest && closed_ring_below_isom_minimum(&x, &y, scalefactor) {
+                        smallringtest = false;
+                        help2.iter_mut().for_each(|h| *h = false);
                     }
                 }
                 if smallringtest {
@@ -860,4 +909,46 @@ pub fn draw_curves(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::closed_ring_below_isom_minimum;
+
+    /// Render pixels per ground metre at 600 dpi, 1:10,000 (the transform in draw_curves).
+    const PX_PER_M: f64 = 600.0 / 254.0;
+
+    /// A square ring of the given ground size, as the renderer would see it.
+    fn ring(metres: f64) -> (Vec<f64>, Vec<f64>) {
+        let s = metres * PX_PER_M;
+        (vec![0.0, s, s, 0.0, 0.0], vec![0.0, 0.0, s, s, 0.0])
+    }
+
+    #[test]
+    fn rings_below_the_isom_minimum_are_rejected() {
+        // ISOM 2017-2 symbol 103: minimum closed form line 1.65 mm at 1:10,000 = 16.5 m.
+        let (x, y) = ring(10.0);
+        assert!(closed_ring_below_isom_minimum(&x, &y, 1.0));
+        let (x, y) = ring(20.0);
+        assert!(!closed_ring_below_isom_minimum(&x, &y, 1.0));
+    }
+
+    #[test]
+    fn an_elongated_ring_is_judged_by_its_longer_side() {
+        // 5 m across but 40 m long: a real feature, not a speck.
+        let s = PX_PER_M;
+        let x = vec![0.0, 40.0 * s, 40.0 * s, 0.0, 0.0];
+        let y = vec![0.0, 0.0, 5.0 * s, 5.0 * s, 0.0];
+        assert!(!closed_ring_below_isom_minimum(&x, &y, 1.0));
+    }
+
+    #[test]
+    fn the_bound_is_ground_distance_not_pixels() {
+        // Same ring, scalefactor 2 => half the pixels for the same ground size, and the
+        // verdict must not change.
+        let (x, y) = ring(20.0);
+        let halved: Vec<f64> = x.iter().map(|v| v / 2.0).collect();
+        let halved_y: Vec<f64> = y.iter().map(|v| v / 2.0).collect();
+        assert!(!closed_ring_below_isom_minimum(&halved, &halved_y, 2.0));
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -766,6 +766,10 @@ pub fn draw_curves(
 
             let mut formiline_points = Vec::new();
 
+            if layer == Classification::SmallDepression {
+                curvew = 3.0;
+            }
+
             for i in 1..x.len() {
                 if curvew != 1.5 || formline == 0.0 || help2[i] || smallringtest {
                     if should_generate_formlines && curvew == 1.5 {

--- a/src/render.rs
+++ b/src/render.rs
@@ -671,28 +671,16 @@ pub fn draw_curves(
                 // Rings under the ISOM minimum are therefore dropped rather than filled
                 // in. Both the raster and the form line vector output are gated on
                 // help2/smallringtest below, so the two stay consistent.
-                smallringtest = false;
-                if x.first() == x.last() && y.first() == y.last() && x.len() < 122 {
-                    for i in 1..x.len() {
-                        if help2[i] {
-                            smallringtest = true
+                for max_length in [122usize, 60].iter() {
+                    smallringtest = false;
+                    if x.first() == x.last() && y.first() == y.last() && x.len() < *max_length {
+                        smallringtest = help2.iter().any(|v| *v);
+                        if smallringtest && closed_ring_below_isom_minimum(&x, &y, scalefactor) {
+                            smallringtest = false;
+                            help2.iter_mut().for_each(|h| *h = false);
                         }
-                    }
-                    if smallringtest && closed_ring_below_isom_minimum(&x, &y, scalefactor) {
-                        smallringtest = false;
-                        help2.iter_mut().for_each(|h| *h = false);
-                    }
-                }
-                if smallringtest {
-                    for i in 1..x.len() {
-                        help2[i] = true;
-                    }
-                }
-                smallringtest = false;
-                if x.first() == x.last() && y.first() == y.last() && x.len() < 60 {
-                    for i in 1..x.len() {
-                        if help2[i] {
-                            smallringtest = true
+                        if smallringtest {
+                            help2.iter_mut().for_each(|h| *h = true);
                         }
                     }
                 }


### PR DESCRIPTION
Code partially borrowed from @malpou fork

This aim to generate maps more conform to ISOM standards regarding how we draw depressions.